### PR TITLE
Add disk type data source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ testacc: fmtcheck
 		echo "Error: Skipping example acceptance testing pattern. Update TESTARGS to match the test naming in the relevant *_test.go file."; \
 		echo "Example:"; \
 		echo ""; \
-		echo "    make testacc TESTARGS='-run=TestAccAnxcloudVirtualServerBasic'"; \
+		echo "    make testacc TESTARGS='-run=TestAccAnxcloudVirtualServer'"; \
 		echo ""; \
 		exit 1; \
 	fi

--- a/anxcloud/data_source_disk_type.go
+++ b/anxcloud/data_source_disk_type.go
@@ -20,7 +20,7 @@ func dataSourceDiskTypeRead(ctx context.Context, d *schema.ResourceData, m inter
 	c := m.(client.Client)
 	t := disktype.NewAPI(c)
 	locationID := d.Get("location_id").(string)
-	diskTypes, err := t.List(ctx, locationID)
+	diskTypes, err := t.List(ctx, locationID, 0, 1000)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/anxcloud/data_source_disk_type.go
+++ b/anxcloud/data_source_disk_type.go
@@ -1,0 +1,34 @@
+package anxcloud
+
+import (
+	"context"
+
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDiskType() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDiskTypeRead,
+		Schema:      schemaDiskType(),
+	}
+}
+
+func dataSourceDiskTypeRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(client.Client)
+	t := disktype.NewAPI(c)
+	locationID := d.Get("location_id").(string)
+	diskTypes, err := t.List(ctx, locationID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("types", flattenDiskTypes(diskTypes)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(locationID)
+	return nil
+}

--- a/anxcloud/data_source_disk_type_test.go
+++ b/anxcloud/data_source_disk_type_test.go
@@ -1,0 +1,59 @@
+package anxcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAnxCloudDiskTypeDataSource(t *testing.T) {
+	resourceName := "acc_test"
+	resourcePath := "data.anxcloud_disk_type." + resourceName
+
+	locationID := "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnxCloudDiskTypeDataSource(resourceName, locationID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
+					resource.TestCheckResourceAttr(resourcePath, "id", locationID),
+					testAccAnxCloudDiskTypeDatSourceExists(resourcePath),
+				),
+			},
+		},
+	})
+}
+
+func testAccAnxCloudDiskTypeDataSource(resourceName, locationID string) string {
+	return fmt.Sprintf(`
+	data "anxcloud_disk_type" "%s" {
+		location_id   = "%s"
+	}
+	`, resourceName, locationID)
+}
+
+func testAccAnxCloudDiskTypeDatSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("disk type not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("disk type id not set")
+		}
+
+		if len(rs.Primary.Attributes) < 1 {
+			return fmt.Errorf("not found disk types")
+		}
+
+		return nil
+	}
+}

--- a/anxcloud/provider.go
+++ b/anxcloud/provider.go
@@ -27,7 +27,9 @@ func Provider() *schema.Provider {
 			"anxcloud_vlan":           resourceVLAN(),
 			"anxcloud_network_prefix": resourceNetworkPrefix(),
 		},
-		DataSourcesMap:       map[string]*schema.Resource{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"anxcloud_disk_type": dataSourceDiskType(),
+		},
 		ConfigureContextFunc: providerConfigure,
 	}
 }

--- a/anxcloud/schema_disk_type.go
+++ b/anxcloud/schema_disk_type.go
@@ -1,0 +1,49 @@
+package anxcloud
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func schemaDiskType() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"location_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Location identifier.",
+		},
+		"types": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "List of available disk types.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Identifier of the disk type.",
+					},
+					"storage_type": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Storage type.",
+					},
+					"bandwidth": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "Bandwidth.",
+					},
+					"iops": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "Disk input/output operations per second.",
+					},
+					"latency": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "Disk latency.",
+					},
+				},
+			},
+		},
+	}
+}

--- a/anxcloud/struct_disk_type.go
+++ b/anxcloud/struct_disk_type.go
@@ -1,0 +1,30 @@
+package anxcloud
+
+import (
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
+)
+
+// expanders
+
+// flatteners
+
+func flattenDiskTypes(in []disktype.DiskType) []interface{} {
+	att := []interface{}{}
+	if len(in) < 1 {
+		return att
+	}
+
+	for _, d := range in {
+		m := map[string]interface{}{}
+
+		m["id"] = d.ID
+		m["storage_type"] = d.StorageType
+		m["bandwidth"] = d.Bandwidth
+		m["iops"] = d.IOPS
+		m["latency"] = d.Latency
+
+		att = append(att, m)
+	}
+
+	return att
+}

--- a/anxcloud/struct_disk_type_test.go
+++ b/anxcloud/struct_disk_type_test.go
@@ -1,0 +1,65 @@
+package anxcloud
+
+import (
+	"testing"
+
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
+	"github.com/google/go-cmp/cmp"
+)
+
+// expanders tests
+
+// flatteners tests
+
+func TestFlattenDiskTypes(t *testing.T) {
+	cases := []struct {
+		Input          []disktype.DiskType
+		ExpectedOutput []interface{}
+	}{
+		{
+			[]disktype.DiskType{
+				{
+					Bandwidth:   300,
+					ID:          "STD6",
+					IOPS:        2600,
+					Latency:     30,
+					StorageType: "HDD",
+				},
+				{
+					Bandwidth:   500,
+					ID:          "HPC1",
+					IOPS:        20000,
+					Latency:     7,
+					StorageType: "SSD",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"bandwidth":    300,
+					"id":           "STD6",
+					"iops":         2600,
+					"latency":      30,
+					"storage_type": "HDD",
+				},
+				map[string]interface{}{
+					"bandwidth":    500,
+					"id":           "HPC1",
+					"iops":         20000,
+					"latency":      7,
+					"storage_type": "SSD",
+				},
+			},
+		},
+		{
+			[]disktype.DiskType{},
+			[]interface{}{},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenDiskTypes(tc.Input)
+		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
+			t.Fatalf("Unexpected output from expander: mismatch (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/docs/data-sources/disk-type.md
+++ b/docs/data-sources/disk-type.md
@@ -1,0 +1,36 @@
+---
+page_title: "disk_type Data Source - terraform-provider-anxcloud"
+subcategory: ""
+description: |-
+  The disk type data source allows you to retrieve information about available disk types for specified location.
+---
+
+# Data Source `disk_type`
+
+The disk type data source allows you to retrieve information about available disk types for specified location.
+
+## Example Usage
+
+```hcl
+data "anxcloud_disk_type" "example" {
+  location_id = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
+}
+```
+
+## Argument Reference
+
+- `location_id` - (Required) Location identifier.
+
+## Attributes Reference
+
+The following attributes are exported.
+
+- `types` - A list of disk types objects. See [Types](#types) below for details.
+
+### Types
+
+- `id` -  Identifier of the disk type.
+- `storage_type` - The disk storage type.
+- `bandwidth` - The disk bandwidth.
+- `iops` - Disk input/output operations per second.
+- `latency` - The disk latency.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -9,6 +9,16 @@ terraform {
 
 provider "anxcloud" {}
 
+data "anxcloud_disk_type" "example" {
+  location_id = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
+}
+
+locals {
+  disk_types = {
+    for obj in data.anxcloud_disk_type.example.types : obj.id => obj
+  }
+}
+
 resource "anxcloud_vlan" "example" {
   location_id = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
   vm_provisioning = true
@@ -21,7 +31,6 @@ resource "anxcloud_network_prefix" "example" {
   ip_version = 4
   type = 0
   netmask = 29
-  vm_provisioning = true
   description_customer = "terraform prefix test"
 }
 
@@ -32,6 +41,7 @@ resource "anxcloud_virtual_server" "example" {
   hostname      = "example-terraform"
   cpus          = 8
   disk          = 70
+  disk_type     = disk_types.STD6.id
   memory        = 4096
   password      = "flatcar#1234$%"
   cpu_performance_type = "standard"

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

### Description
Add disk type data source.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAnxCloudDiskTypeDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -v -run=TestAccAnxCloudDiskTypeDataSource -timeout 120m -parallel=4
?       github.com/anexia-it/terraform-provider-anxcloud        [no test files]
=== RUN   TestAccAnxCloudDiskTypeDataSource
--- PASS: TestAccAnxCloudDiskTypeDataSource (2.08s)
PASS
ok      github.com/anexia-it/terraform-provider-anxcloud/anxcloud       2.087s
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add disk type data source.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
