### PR TITLE
add import functionality for tag and network_prefix

### DIFF
--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -42,17 +42,14 @@ func resourceNetworkPrefixCreate(ctx context.Context, d *schema.ResourceData, m 
 	locationID := d.Get("location_id").(string)
 
 	createParams := prefix.Create{
-		Location:                locationID,
-		IPVersion:               d.Get("ip_version").(int),
-		Type:                    d.Get("type").(int),
-		NetworkMask:             d.Get("netmask").(int),
-		CreateVLAN:              d.Get("new_vlan").(bool),
-		VLANID:                  d.Get("vlan_id").(string),
-		EnableRedundancy:        d.Get("router_redundancy").(bool),
-		EnableVMProvisioning:    d.Get("vm_provisioning").(bool),
-		CustomerDescription:     d.Get("description_customer").(string),
-		CustomerVLANDescription: d.Get("description_vlan_customer").(string),
-		Organization:            d.Get("organization").(string),
+		Location:            locationID,
+		IPVersion:           d.Get("ip_version").(int),
+		Type:                d.Get("type").(int),
+		NetworkMask:         d.Get("netmask").(int),
+		VLANID:              d.Get("vlan_id").(string),
+		EnableRedundancy:    d.Get("router_redundancy").(bool),
+		CustomerDescription: d.Get("description_customer").(string),
+		Organization:        d.Get("organization").(string),
 	}
 	res, err := p.Create(ctx, createParams)
 	if err != nil {
@@ -115,6 +112,17 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	if err := d.Set("locations", flattenNetworkPrefixLocations(info.Locations)); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if len(info.Locations) > 0 {
+		if err := d.Set("location_id", info.Locations[0].ID); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+	if err := d.Set("router_redundancy", info.RouterRedundancy); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("vlan_id", info.VLANID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 

--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -29,6 +29,9 @@ func resourceNetworkPrefix() *schema.Resource {
 			Update: schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: schemaNetworkPrefix(),
 	}
 }

--- a/anxcloud/resource_network_prefix_test.go
+++ b/anxcloud/resource_network_prefix_test.go
@@ -28,7 +28,6 @@ func TestAccAnxCloudNetworkPrefix(t *testing.T) {
 				Config: testAccAnxCloudNetworkPrefix(resourceName, locationID, customerDescription),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
-					resource.TestCheckResourceAttr(resourcePath, "vm_provisioning", "true"),
 					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescription),
 					testAccAnxCloudNetworkPrefixExists(resourcePath, customerDescription),
 				),
@@ -37,7 +36,6 @@ func TestAccAnxCloudNetworkPrefix(t *testing.T) {
 				Config: testAccAnxCloudNetworkPrefix(resourceName, locationID, customerDescriptionUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
-					resource.TestCheckResourceAttr(resourcePath, "vm_provisioning", "true"),
 					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
 					testAccAnxCloudNetworkPrefixExists(resourcePath, customerDescriptionUpdate),
 				),
@@ -86,7 +84,6 @@ func testAccAnxCloudNetworkPrefix(resourceName, locationID, customerDescription 
 		vlan_id = "02f39d20ca0f4adfb5032f88dbc26c39"
 		ip_version = 4
 		netmask = 30
-		vm_provisioning = true
 		description_customer = "%s"
 	}
 	`, resourceName, locationID, customerDescription)

--- a/anxcloud/resource_network_prefix_test.go
+++ b/anxcloud/resource_network_prefix_test.go
@@ -42,6 +42,11 @@ func TestAccAnxCloudNetworkPrefix(t *testing.T) {
 					testAccAnxCloudNetworkPrefixExists(resourcePath, customerDescriptionUpdate),
 				),
 			},
+			{
+				ResourceName:      resourcePath,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/anxcloud/resource_tag.go
+++ b/anxcloud/resource_tag.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// TODO tags currently only works if they are attached to a compute resource.
+// we’ll need a rewrite of it after we come to a second service which is also using tags.
+
 func resourceTag() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceTagCreate,
@@ -20,6 +23,9 @@ func resourceTag() *schema.Resource {
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: schemaTag(),
 	}
@@ -59,6 +65,13 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		return nil
 	}
 
+	if err := d.Set("name", info.Name); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	err = d.Set("service_id", info.Organisations[0].Service.Identifier)
+	if err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
 	if err := d.Set("organisation_assignments", flattenOrganisationAssignments(info.Organisations)); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/anxcloud/resource_tag_test.go
+++ b/anxcloud/resource_tag_test.go
@@ -30,6 +30,11 @@ func TestAccAnxCloudTag(t *testing.T) {
 					testAccAnxCloudTagExists(resourcePath),
 				),
 			},
+			{
+				ResourceName:      resourcePath,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/anxcloud/schema_network_prefix.go
+++ b/anxcloud/schema_network_prefix.go
@@ -30,14 +30,6 @@ func schemaNetworkPrefix() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "The Prefix type: 0 = Public, 1 = Private.",
 		},
-		"new_vlan": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			ForceNew: true,
-			Default:  false,
-			Description: "If new VLAN shall be created. WARNING, the VLAN status won't be reflected in the terraform status." +
-				"Use at your own risk.",
-		},
 		"vlan_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -47,32 +39,17 @@ func schemaNetworkPrefix() map[string]*schema.Schema {
 		"router_redundancy": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			ForceNew:    true,
 			Default:     false,
 			Description: "If router Redundancy shall be enabled.",
-		},
-		"vm_provisioning": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			ForceNew:    true,
-			Default:     false,
-			Description: "If VM provisioning shall be enabled.",
 		},
 		"description_customer": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Additional description.",
 		},
-		"description_vlan_customer": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			ForceNew:    true,
-			Description: "Additional description for the generated VLAN if new_vlan.",
-		},
 		"organization": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			ForceNew:    true,
 			Description: "Customer of yours. Reseller only.",
 		},
 		"status": {

--- a/docs/resources/network_prefix.md
+++ b/docs/resources/network_prefix.md
@@ -29,11 +29,8 @@ resource "anxcloud_network_prefix" "example" {
 - `netmask` - (Required) Netmask size. Example: 29 which would result in x.x.x.x/29.
 - `ip_version` - (Optional) The Prefix version: 4 = IPv4, 6 = IPv6.
 - `type` - (Optional) The Prefix type: 0 = Public, 1 = Private.
-- `new_vlan` - (Optional) If a new VLAN shall be created. WARNING, the VLAN status won't be reflected in the terraform status. Use at your own risk.
-- `description_vlan_customer` - (Optional) Additional description for the generated VLAN if new_vlan.
 - `vlan_id` - (Optional) Identifier for the related VLAN. Not applicable when using `new_vlan` option.
 - `router_redundancy` - (Optional) If router Redundancy shall be enabled.
-- `vm_provisioning` - (Optional) True if VM provisioning shall be enabled. Defaults to false.
 - `description_customer` - (Optional) Additional customer description.
 - `organization` - (Optional) Customer of yours. Reseller only.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/anexia-it/terraform-provider-anxcloud
 go 1.14
 
 require (
-	github.com/anexia-it/go-anxcloud v0.3.13
+	github.com/anexia-it/go-anxcloud v0.3.15
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/google/go-cmp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/anexia-it/terraform-provider-anxcloud
 go 1.14
 
 require (
-	github.com/anexia-it/go-anxcloud v0.3.12
+	github.com/anexia-it/go-anxcloud v0.3.14
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/anexia-it/go-anxcloud v0.3.12 h1:5OJzBFRj/HogUVMm7z6OD9tsFGy1vufNWJI3FUxxIKg=
-github.com/anexia-it/go-anxcloud v0.3.12/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
+github.com/anexia-it/go-anxcloud v0.3.14 h1:bsizZv0c+oqgd/m1h0LTx9WE3tx/hLhZ8g90Fw2YzRU=
+github.com/anexia-it/go-anxcloud v0.3.14/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/go.sum
+++ b/go.sum
@@ -40,13 +40,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-<<<<<<< HEAD
-github.com/anexia-it/go-anxcloud v0.3.14 h1:bsizZv0c+oqgd/m1h0LTx9WE3tx/hLhZ8g90Fw2YzRU=
-github.com/anexia-it/go-anxcloud v0.3.14/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
-=======
-github.com/anexia-it/go-anxcloud v0.3.13 h1:Zy5L/w5Wt0rGy9qgGoArFPgMAfh7t8WzlqU/2+6VyKE=
-github.com/anexia-it/go-anxcloud v0.3.13/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
->>>>>>> upstream/main
+github.com/anexia-it/go-anxcloud v0.3.15 h1:C65z4SoRRHuo24CqMYxvYOz228D++bGVo4BlQKtS1PE=
+github.com/anexia-it/go-anxcloud v0.3.15/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=


### PR DESCRIPTION
### Description

Add import functionality for tag and network_prefix

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAnxCloudTag'
make testacc TESTARGS='-run=TestAccAnxCloudVSphereLocationsDataSource'
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add import functionality for tag and network_prefix
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
