### PR TITLE
Multi disk support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ HOSTNAME=hashicorp.com
 NAMESPACE=anexia-it
 NAME=anxcloud
 BINARY=terraform-provider-${NAME}
-VERSION=0.2.5
+VERSION=0.2.3
 OS_ARCH=linux_amd64
 
 TEST?=$$(go list ./... | grep -v 'vendor')

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ HOSTNAME=hashicorp.com
 NAMESPACE=anexia-it
 NAME=anxcloud
 BINARY=terraform-provider-${NAME}
-VERSION=0.2.3
+VERSION=0.2.5
 OS_ARCH=linux_amd64
 
 TEST?=$$(go list ./... | grep -v 'vendor')

--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -122,9 +122,10 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 	if err := d.Set("router_redundancy", info.RouterRedundancy); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if err := d.Set("vlan_id", info.VLANID); err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	//if err := d.Set("vlan_id", info.VLANID); err != nil {
+	//	diags = append(diags, diag.FromErr(err)...)
+	//}
+
 
 	return diags
 }

--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -122,7 +122,7 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 	if err := d.Set("router_redundancy", info.RouterRedundancy); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if err := d.Set("vlan_id", info.VLANID); err != nil {
+	if err := d.Set("vlan_id", info.Vlans[0].ID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 

--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -122,10 +122,9 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 	if err := d.Set("router_redundancy", info.RouterRedundancy); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	//if err := d.Set("vlan_id", info.VLANID); err != nil {
-	//	diags = append(diags, diag.FromErr(err)...)
-	//}
-
+	if err := d.Set("vlan_id", info.VLANID); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
 
 	return diags
 }

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -304,8 +304,7 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 		//if i < len(specDisks) {
 		//	specDisks[i].ID = diskInfo.DiskID
 		//	disks = append(disks, specDisks[i])
-		//	continue
-		//}
+		//	continue //}
 		disk := vm.Disk{
 			ID:      diskInfo.DiskID,
 			Type:    diskInfo.DiskType,
@@ -450,7 +449,6 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 		log.Println("AddDisks: ", addDisks)
 		ch.ChangeDisks = changeDisks
 		ch.AddDisks = addDisks
-		requiresReboot = true
 	}
 
 	if d.HasChange("tags") {
@@ -473,7 +471,6 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 			}
 		}
 	}
-	ch.Reboot = requiresReboot
 
 	var response vm.ProvisioningResponse
 	provisioning := v.Provisioning()

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -302,8 +302,6 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	log.Println("Updated Disks from Info: ", fDisks)
-
 	specNetworks := expandVirtualServerNetworks(d.Get("network").([]interface{}))
 	var networks []vm.Network
 	for i, net := range info.Network {

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -2,7 +2,6 @@ package anxcloud
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -227,13 +226,15 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	if read := resourceVirtualServerRead(ctx, d, m); read.HasError() {
-		return read
-	}
+	if len(disks) > 1 {
+		if read := resourceVirtualServerRead(ctx, d, m); read.HasError() {
+			return read
+		}
 
-	initialDisks := expandVirtualServerDisks(d.Get("disks").([]interface{}))
-	if update := updateVirtualServerDisk(ctx, c, d.Id(), disks, initialDisks); update != nil {
-		return update
+		initialDisks := expandVirtualServerDisks(d.Get("disks").([]interface{}))
+		if update := updateVirtualServerDisk(ctx, c, d.Id(), disks, initialDisks); update != nil {
+			return update
+		}
 	}
 
 	diags = resourceVirtualServerRead(ctx, d, m)
@@ -545,11 +546,6 @@ func updateVirtualServerDisk(ctx context.Context, c client.Client, id string, ex
 		AddDisks:    addDisks,
 		ChangeDisks: changeDisks,
 	}
-	request, jErr := json.Marshal(ch)
-	if jErr != nil {
-		panic(jErr)
-	}
-	log.Println(string(request))
 
 	v := vsphere.NewAPI(c)
 	var response vm.ProvisioningResponse

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -189,6 +189,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		Memory:             d.Get("memory").(int),
 		CPUs:               d.Get("cpus").(int),
 		Disk:               disks[0].SizeGBs, //Workaround until Create API supports multi disk
+		DiskType:           disks[0].Type,
 		CPUPerformanceType: d.Get("cpu_performance_type").(string),
 		Sockets:            d.Get("sockets").(int),
 		Network:            networks,

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -193,7 +193,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("unable to get vm progress by ID '%s', %w", provision.Identifier, err))
 			}
-			if p.VMIdentifier != "" {
+			if p.VMIdentifier != "" && p.Progress < 100 {
 				d.SetId(p.VMIdentifier)
 			} else {
 				return resource.RetryableError(fmt.Errorf("vm with provisioning ID '%s' is not ready yet: %d %%", provision.Identifier, p.Progress))
@@ -490,7 +490,6 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 	delay := 10 * time.Second
 	if requiresReboot {
 		delay = 3 * time.Minute
-
 	}
 
 	vmState := resource.StateChangeConf{
@@ -610,7 +609,14 @@ func updateVirtualServerDisk(ctx context.Context, c client.Client, id string, ex
 	log.Println(string(request))
 
 	v := vsphere.NewAPI(c)
-	if _, err := v.Provisioning().VM().Update(ctx, id, ch); err != nil {
+	var response vm.ProvisioningResponse
+	provisioning := v.Provisioning()
+	var err error
+	if response, err = provisioning.VM().Update(ctx, id, ch); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if _, err = provisioning.Progress().AwaitCompletion(ctx, response.Identifier); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -634,8 +640,7 @@ func updateVirtualServerDisk(ctx context.Context, c client.Client, id string, ex
 			return info, info.Status, nil
 		},
 	}
-	_, err := vmState.WaitForStateContext(ctx)
-	if err != nil {
+	if _, err = vmState.WaitForStateContext(ctx); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -284,13 +284,12 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 	if err = d.Set("location_id", info.LocationID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	fmt.Println(d.Get("location_id"))
 	if err = d.Set("template_id", info.TemplateID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if err = d.Set("template_type", info.TemplateType); err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	//if err = d.Set("template_type", info.TemplateType); err != nil {
+	//	diags = append(diags, diag.FromErr(err)...)
+	//}
 	if err = d.Set("cpus", info.CPU); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -127,7 +127,6 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 	}
 
 	t.Run("AddDisk", func(t *testing.T) {
-		t.Parallel()
 		addDiskDef := vmDef
 		addDiskDef.Hostname = "acc-test-" + shortuuid.New()
 
@@ -149,7 +148,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 					),
 				},
 				{
-					Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disksAdd),
+					Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &addDiskDef, disksAdd),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckAnxCloudVirtualServerDisks(resourcePath, disksAdd),
 					),
@@ -159,7 +158,6 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 	})
 
 	t.Run("ChangeAddDisk", func(t *testing.T) {
-		t.Parallel()
 		changeDiskDef := vmDef
 		changeDiskDef.Hostname = "acc-test-" + shortuuid.New()
 
@@ -183,7 +181,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 					),
 				},
 				{
-					Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disksChange),
+					Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &changeDiskDef, disksChange),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckAnxCloudVirtualServerDisks(resourcePath, disksChange),
 					),
@@ -193,7 +191,6 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 	})
 
 	t.Run("MultiDiskTemplateChange", func(t *testing.T) {
-		t.Parallel()
 		changeDiskDef := vmDef
 		changeDiskDef.Hostname = "acc-test-" + shortuuid.New()
 		changeDiskDef.TemplateID = "44eeae8b-fc8d-4e0f-a4ad-c16db54976a3"

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -167,7 +167,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 		})
 
 		disksChange[0].SizeGBs = 70
-		disksChange[0].Type = "Ent1"
+		disksChange[0].Type = "ENT1"
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { testAccPreCheck(t) },
@@ -201,7 +201,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 				SizeGBs: 50,
 			},
 			{
-				Type:    "Ent6",
+				Type:    "ENT6",
 				SizeGBs: 50,
 			},
 		}

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -27,6 +27,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 		CPUs:               1,
 		CPUPerformanceType: "performance",
 		Disk:               50,
+		DiskType:           "ENT6",
 		Network: []vm.Network{
 			{
 				VLAN:    "02f39d20ca0f4adfb5032f88dbc26c39",
@@ -192,13 +193,14 @@ func testAccCheckAnxCloudVirtualServerDestroy(s *terraform.State) error {
 func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition) string {
 	return fmt.Sprintf(`
 	resource "anxcloud_virtual_server" "%s" {
-		location_id   = "%s"
-		template_id   = "%s"
-		template_type = "%s"
-		hostname      = "%s"
-		cpus          = %d
-		memory        = %d
-		password      = "%s"
+		location_id          = "%s"
+		template_id          = "%s"
+		template_type        = "%s"
+		hostname             = "%s"
+		cpus                 = %d
+		cpu_performance_type = "%s"
+		memory               = %d
+		password             = "%s"
 
 		// generated network string
 		%s
@@ -209,10 +211,11 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition)
 		force_restart_if_needed = true
 		critical_operation_confirmed = true
 	}
-	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.Memory,
+	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.CPUPerformanceType, def.Memory,
 		def.Password, generateNetworkSubResourceString(def.Network), generateDisksSubResourceString([]vm.Disk{
 			{
 				SizeGBs: def.Disk,
+				Type:    def.DiskType,
 			},
 		}))
 }

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -24,7 +24,8 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 		TemplateID:   "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
 		Hostname:     "acc-test-" + shortuuid.New(),
 		Memory:       2048,
-		CPUs:         2,
+		CPUs:         1,
+		CPUPerformanceType: "performance",
 		Disk:         50,
 		Network: []vm.Network{
 			{
@@ -39,7 +40,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 
 	// upscale resources
 	vmDefUpscale := vmDef
-	vmDefUpscale.CPUs = 4
+	vmDefUpscale.CPUs = 2
 	vmDefUpscale.Disk = 80
 	vmDefUpscale.Memory = 4096
 	vmDefUpscale.Network = append(vmDefUpscale.Network, vm.Network{
@@ -110,6 +111,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 		Hostname:     "acc-test-" + shortuuid.New(),
 		Memory:       2048,
 		CPUs:         2,
+		CPUPerformanceType: "performance",
 		Network: []vm.Network{
 			{
 				VLAN:    "02f39d20ca0f4adfb5032f88dbc26c39",
@@ -122,17 +124,17 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 
 	disks := []vm.Disk{
 		{
-			Type:    "STD1",
+			Type:    "ENT1",
 			SizeGBs: 40,
 		},
 		{
-			Type:    "STD1",
+			Type:    "ENT1",
 			SizeGBs: 40,
 		},
 	}
 
 	disksUpscale := disks
-	disksUpscale[1].Type = "ENT1"
+	disksUpscale[1].Type = "ENT6"
 	disksUpscale[1].SizeGBs = 50
 
 	resource.Test(t, resource.TestCase{
@@ -188,7 +190,7 @@ func testAccCheckAnxCloudVirtualServerDestroy(s *terraform.State) error {
 }
 
 func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition) string {
-	x := fmt.Sprintf(`
+	return fmt.Sprintf(`
 	resource "anxcloud_virtual_server" "%s" {
 		location_id   = "%s"
 		template_id   = "%s"
@@ -213,8 +215,6 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition)
 				SizeGBs: def.Disk,
 			},
 		}))
-	fmt.Println(x)
-	return x
 }
 
 func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def *vm.Definition, disks []vm.Disk) string {

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -333,7 +333,7 @@ func generateNetworkSubResourceString(networks []vm.Network) string {
 
 func generateDisksSubResourceString(disks []vm.Disk) string {
 	var output string
-	template := "\ndisks {\n\tdisk = %d\n\tdisk_type = \"%s\"\n}\n"
+	template := "\ndisks {\n\tdisk_gb = %d\n\tdisk_type = \"%s\"\n}\n"
 
 	for _, d := range disks {
 		output += fmt.Sprintf(template, d.SizeGBs, d.Type)

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -42,7 +42,6 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 	// upscale resources
 	vmDefUpscale := vmDef
 	vmDefUpscale.CPUs = 2
-	vmDefUpscale.Disk = 80
 	vmDefUpscale.Memory = 4096
 	vmDefUpscale.Network = append(vmDefUpscale.Network, vm.Network{
 		VLAN:    "02f39d20ca0f4adfb5032f88dbc26c39",
@@ -51,7 +50,6 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 
 	// down scale resources which does not require recreation of the VM
 	vmDefDownscale := vmDefUpscale
-	vmDefDownscale.CPUs = 2
 	vmDefDownscale.Memory = 2096
 
 	resource.Test(t, resource.TestCase{
@@ -67,7 +65,6 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDef.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDef.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDef.Memory)),
-					//resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDef.Disk)),
 				),
 			},
 			{
@@ -78,7 +75,6 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDefUpscale.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDefUpscale.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDefUpscale.Memory)),
-					//resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDefUpscale.Disk)),
 				),
 			},
 			{
@@ -89,13 +85,13 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDefDownscale.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDefDownscale.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDefDownscale.Memory)),
-					//resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDefDownscale.Disk)),
 				),
 			},
 			{
-				ResourceName:      resourcePath,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourcePath,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cpu_performance_type", "critical_operation_confirmed", "enter_bios_setup", "force_restart_if_needed", "hostname", "password", "template_type"},
 			},
 		},
 	})
@@ -147,14 +143,12 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 				Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disks),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerDisks(resourcePath, disks),
-					resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDef.Disk)),
 				),
 			},
 			{
 				Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disksUpscale),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerDisks(resourcePath, disksUpscale),
-					resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDef.Disk)),
 				),
 			},
 		},
@@ -229,7 +223,6 @@ func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def
 		hostname      = "%s"
 		cpus          = %d
 		memory        = %d
-		disk          = %d
 		password      = "%s"
 
 		// generated network string
@@ -241,7 +234,7 @@ func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def
 		force_restart_if_needed = true
 		critical_operation_confirmed = true
 	}
-	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.Memory, def.Disk,
+	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.Memory,
 		def.Password, generateNetworkSubResourceString(def.Network), generateDisksSubResourceString(disks))
 }
 

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -98,6 +98,65 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 	})
 }
 
+func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
+	resourceName := "acc_test_vm_test_multi_disk"
+	resourcePath := "anxcloud_virtual_server." + resourceName
+
+	vmDef := vm.Definition{
+		Location:     "52b5f6b2fd3a4a7eaaedf1a7c019e9ea",
+		TemplateType: "templates",
+		TemplateID:   "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
+		Hostname:     "acc-test-" + shortuuid.New(),
+		Memory:       2048,
+		CPUs:         2,
+		Network: []vm.Network{
+			{
+				VLAN:    "02f39d20ca0f4adfb5032f88dbc26c39",
+				NICType: "vmxnet3",
+			},
+		},
+		DNS1:     "8.8.8.8",
+		Password: "flatcar#1234$%%",
+	}
+
+	disks := []vm.Disk{
+		{
+			Type:    "STD1",
+			SizeGBs: 40,
+		},
+		{
+			Type:    "STD1",
+			SizeGBs: 40,
+		},
+	}
+
+	disksUpscale := disks
+	disksUpscale[1].Type = "ENT1"
+	disksUpscale[1].SizeGBs = 50
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAnxCloudVirtualServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disks),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnxCloudVirtualServerDisks(resourcePath, disks),
+					resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDef.Disk)),
+				),
+			},
+			{
+				Config: testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName, &vmDef, disksUpscale),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnxCloudVirtualServerDisks(resourcePath, disksUpscale),
+					resource.TestCheckResourceAttr(resourcePath, "disk", strconv.Itoa(vmDef.Disk)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAnxCloudVirtualServerDestroy(s *terraform.State) error {
 	c := testAccProvider.Meta().(client.Client)
 	v := vsphere.NewAPI(c)
@@ -147,6 +206,31 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition)
 	}
 	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.Memory, def.Disk,
 		def.Password, generateNetworkSubResourceString(def.Network))
+}
+
+func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def *vm.Definition, disks []vm.Disk) string {
+	return fmt.Sprintf(`
+	resource "anxcloud_virtual_server" "%s" {
+		location_id   = "%s"
+		template_id   = "%s"
+		template_type = "%s"
+		hostname      = "%s"
+		cpus          = %d
+		memory        = %d
+		disk          = %d
+		password      = "%s"
+
+		// generated network string
+		%s
+
+		// generated disks string
+		%s
+
+		force_restart_if_needed = true
+		critical_operation_confirmed = true
+	}
+	`, resourceName, def.Location, def.TemplateID, def.TemplateType, def.Hostname, def.CPUs, def.Memory, def.Disk,
+		def.Password, generateNetworkSubResourceString(def.Network), generateDisksSubResourceString(disks))
 }
 
 func testAccCheckAnxCloudVirtualServerExists(n string, def *vm.Definition) resource.TestCheckFunc {
@@ -200,12 +284,59 @@ func testAccCheckAnxCloudVirtualServerExists(n string, def *vm.Definition) resou
 	}
 }
 
+func testAccCheckAnxCloudVirtualServerDisks(n string, expectedDisks []vm.Disk) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		c := testAccProvider.Meta().(client.Client)
+		v := vsphere.NewAPI(c)
+		ctx := context.Background()
+
+		if !ok {
+			return fmt.Errorf("virtual server not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("virtual server id not set")
+		}
+
+		info, err := v.Info().Get(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(info.DiskInfo) != len(expectedDisks) {
+			return fmt.Errorf("virtual machine disk count do not match, got %d - expected %d", len(info.DiskInfo), len(expectedDisks))
+		}
+
+		for i, d := range info.DiskInfo {
+			if d.DiskType != expectedDisks[i].Type {
+				return fmt.Errorf("virtual machine disk with ID %d has incorrect type, got %s - expected %s", d.DiskID, d.DiskType, expectedDisks[i].Type)
+			} else if d.DiskGB != expectedDisks[i].SizeGBs {
+				return fmt.Errorf("virtual machine disk with ID %d has incorrect size, got %d - expected %d", d.DiskID, d.DiskGB, expectedDisks[i].SizeGBs)
+			}
+		}
+
+		return nil
+	}
+}
+
 func generateNetworkSubResourceString(networks []vm.Network) string {
 	var output string
 	template := "\nnetwork {\n\tvlan_id = \"%s\"\n\tnic_type = \"%s\"\n}\n"
 
 	for _, n := range networks {
 		output += fmt.Sprintf(template, n.VLAN, n.NICType)
+	}
+
+	return output
+}
+
+func generateDisksSubResourceString(disks []vm.Disk) string {
+	var output string
+	template := "\ndisks {\n\tdisk = %d\n\tdisk_type = \"%s\"\n}\n"
+
+	for _, d := range disks {
+		output += fmt.Sprintf(template, d.SizeGBs, d.Type)
 	}
 
 	return output

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -19,14 +19,14 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 	resourcePath := "anxcloud_virtual_server." + resourceName
 
 	vmDef := vm.Definition{
-		Location:     "52b5f6b2fd3a4a7eaaedf1a7c019e9ea",
-		TemplateType: "templates",
-		TemplateID:   "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
-		Hostname:     "acc-test-" + shortuuid.New(),
-		Memory:       2048,
-		CPUs:         1,
+		Location:           "52b5f6b2fd3a4a7eaaedf1a7c019e9ea",
+		TemplateType:       "templates",
+		TemplateID:         "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
+		Hostname:           "acc-test-" + shortuuid.New(),
+		Memory:             2048,
+		CPUs:               1,
 		CPUPerformanceType: "performance",
-		Disk:         50,
+		Disk:               50,
 		Network: []vm.Network{
 			{
 				VLAN:    "02f39d20ca0f4adfb5032f88dbc26c39",
@@ -105,12 +105,12 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 	resourcePath := "anxcloud_virtual_server." + resourceName
 
 	vmDef := vm.Definition{
-		Location:     "52b5f6b2fd3a4a7eaaedf1a7c019e9ea",
-		TemplateType: "templates",
-		TemplateID:   "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
-		Hostname:     "acc-test-" + shortuuid.New(),
-		Memory:       2048,
-		CPUs:         2,
+		Location:           "52b5f6b2fd3a4a7eaaedf1a7c019e9ea",
+		TemplateType:       "templates",
+		TemplateID:         "12c28aa7-604d-47e9-83fb-5f1d1f1837b3",
+		Hostname:           "acc-test-" + shortuuid.New(),
+		Memory:             2048,
+		CPUs:               2,
 		CPUPerformanceType: "performance",
 		Network: []vm.Network{
 			{

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -61,7 +61,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmDef),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmDef),
-					//resource.TestCheckResourceAttr(resourcePath, "location_id", vmDef.Location),
+					resource.TestCheckResourceAttr(resourcePath, "location_id", vmDef.Location),
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDef.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDef.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDef.Memory)),
@@ -72,7 +72,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmDefUpscale),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmDefUpscale),
-					//resource.TestCheckResourceAttr(resourcePath, "location_id", vmDefUpscale.Location),
+					resource.TestCheckResourceAttr(resourcePath, "location_id", vmDefUpscale.Location),
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDefUpscale.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDefUpscale.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDefUpscale.Memory)),
@@ -188,7 +188,7 @@ func testAccCheckAnxCloudVirtualServerDestroy(s *terraform.State) error {
 }
 
 func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition) string {
-	return fmt.Sprintf(`
+	x := fmt.Sprintf(`
 	resource "anxcloud_virtual_server" "%s" {
 		location_id   = "%s"
 		template_id   = "%s"
@@ -213,6 +213,8 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, def *vm.Definition)
 				SizeGBs: def.Disk,
 			},
 		}))
+	fmt.Println(x)
+	return x
 }
 
 func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def *vm.Definition, disks []vm.Disk) string {

--- a/anxcloud/schema_network_prefix.go
+++ b/anxcloud/schema_network_prefix.go
@@ -30,30 +30,10 @@ func schemaNetworkPrefix() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "The Prefix type: 0 = Public, 1 = Private.",
 		},
-		"vlans": {
-			Type:        schema.TypeList,
+		"vlan_id": {
+			Type:        schema.TypeString,
 			Optional:    true,
-			ForceNew:    true,
-			Description: "Identifier for the related VLAN.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"identifier": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "Network prefix identifier",
-					},
-					"name": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: "Network prefix name",
-					},
-					"description_customer": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "Network prefix customer description",
-					},
-				},
-			},
+			Description: "The corresponding VLAN ID",
 		},
 		"router_redundancy": {
 			Type:        schema.TypeBool,

--- a/anxcloud/schema_network_prefix.go
+++ b/anxcloud/schema_network_prefix.go
@@ -38,18 +38,18 @@ func schemaNetworkPrefix() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"identifier": {
-						Type:             schema.TypeString,
-						Optional: true,
+						Type:        schema.TypeString,
+						Optional:    true,
 						Description: "Network prefix identifier",
 					},
 					"name": {
-						Type: schema.TypeString,
-						Required: true,
+						Type:        schema.TypeString,
+						Required:    true,
 						Description: "Network prefix name",
 					},
 					"description_customer": {
-						Type: schema.TypeString,
-						Optional: true,
+						Type:        schema.TypeString,
+						Optional:    true,
 						Description: "Network prefix customer description",
 					},
 				},

--- a/anxcloud/schema_network_prefix.go
+++ b/anxcloud/schema_network_prefix.go
@@ -30,11 +30,30 @@ func schemaNetworkPrefix() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "The Prefix type: 0 = Public, 1 = Private.",
 		},
-		"vlan_id": {
-			Type:        schema.TypeString,
+		"vlans": {
+			Type:        schema.TypeList,
 			Optional:    true,
 			ForceNew:    true,
 			Description: "Identifier for the related VLAN.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"identifier": {
+						Type:             schema.TypeString,
+						Optional: true,
+						Description: "Network prefix identifier",
+					},
+					"name": {
+						Type: schema.TypeString,
+						Required: true,
+						Description: "Network prefix name",
+					},
+					"description_customer": {
+						Type: schema.TypeString,
+						Optional: true,
+						Description: "Network prefix customer description",
+					},
+				},
+			},
 		},
 		"router_redundancy": {
 			Type:        schema.TypeBool,

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -78,11 +78,11 @@ func schemaVirtualServer() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.",
 					},
-					//"disk_id": {
-					//	Type:        schema.TypeInt,
-					//	Optional:    true,
-					//	Description: "Device ID of the disk on.",
-					//},
+					"disk_id": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "Device ID of the disk on.",
+					},
 				},
 			},
 		},

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -54,13 +54,37 @@ func schemaVirtualServer() map[string]*schema.Schema {
 		},
 		"disk": {
 			Type:        schema.TypeInt,
-			Required:    true,
+			Optional:    true,
 			Description: "Requested disk capacity in GB.",
 		},
 		"disk_type": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.",
+		},
+		"disks": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Virtual Server Disks",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"disk": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Requested disk capacity in GB.",
+					},
+					"disk_type": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.",
+					},
+					//"disk_id": {
+					//	Type:        schema.TypeInt,
+					//	Optional:    true,
+					//	Description: "Device ID of the disk on.",
+					//},
+				},
+			},
 		},
 		"network": {
 			Type:        schema.TypeList,

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -70,7 +70,7 @@ func schemaVirtualServer() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"disk": {
 						Type:        schema.TypeInt,
-						Optional:    true,
+						Required:    true,
 						Description: "Requested disk capacity in GB.",
 					},
 					"disk_type": {

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -68,7 +68,7 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			Description: "Virtual Server Disks",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"disk": {
+					"disk_gb": {
 						Type:        schema.TypeInt,
 						Required:    true,
 						Description: "Requested disk capacity in GB.",

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -283,7 +283,7 @@ func schemaVirtualServer() map[string]*schema.Schema {
 					},
 					"network": {
 						Type:        schema.TypeList,
-						Optional:    true,
+						Computed:    true,
 						Description: "Network interfaces",
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -52,16 +52,6 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			Required:    true,
 			Description: "Memory in MB.",
 		},
-		"disk": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Description: "Requested disk capacity in GB.",
-		},
-		"disk_type": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.",
-		},
 		"disks": {
 			Type:        schema.TypeList,
 			Optional:    true,

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -52,9 +52,9 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			Required:    true,
 			Description: "Memory in MB.",
 		},
-		"disks": {
+		"disk": {
 			Type:        schema.TypeList,
-			Optional:    true,
+			Required:    true,
 			Description: "Virtual Server Disks",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -52,9 +52,9 @@ func expandVirtualServerDisks(p []interface{}) []vm.Disk {
 		if v, ok := in["disk"]; ok {
 			disk.SizeGBs = v.(int)
 		}
-		//if v, ok := in["disk_id"]; ok {
-		//	disk.ID = v.(int)
-		//}
+		if v, ok := in["disk_id"]; ok {
+			disk.ID = v.(int)
+		}
 
 		disks = append(disks, disk)
 	}
@@ -281,7 +281,7 @@ func flattenVirtualServerDisks(in []vm.Disk) []interface{} {
 		net := map[string]interface{}{}
 		net["disk_type"] = d.Type
 		net["disk"] = d.SizeGBs
-		//net["disk_id"] = d.ID
+		net["disk_id"] = d.ID
 		att = append(att, net)
 	}
 

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -36,6 +36,32 @@ func expandVirtualServerNetworks(p []interface{}) []vm.Network {
 	return networks
 }
 
+func expandVirtualServerDisks(p []interface{}) []vm.Disk {
+	var disks []vm.Disk
+	if len(p) < 1 {
+		return disks
+	}
+
+	for _, elem := range p {
+		in := elem.(map[string]interface{})
+		disk := vm.Disk{}
+
+		if v, ok := in["disk_type"]; ok {
+			disk.Type = v.(string)
+		}
+		if v, ok := in["disk"]; ok {
+			disk.SizeGBs = v.(int)
+		}
+		//if v, ok := in["disk_id"]; ok {
+		//	disk.ID = v.(int)
+		//}
+
+		disks = append(disks, disk)
+	}
+
+	return disks
+}
+
 func expandVirtualServerDNS(p []interface{}) (dns [maxDNSEntries]string) {
 	if len(p) < 1 {
 		return dns
@@ -243,4 +269,21 @@ func flattenVirtualServerInfo(in *info.Info) []interface{} {
 	att["network"] = networkInfo
 
 	return []interface{}{att}
+}
+
+func flattenVirtualServerDisks(in []vm.Disk) []interface{} {
+	att := []interface{}{}
+	if len(in) < 1 {
+		return att
+	}
+
+	for _, d := range in {
+		net := map[string]interface{}{}
+		net["disk_type"] = d.Type
+		net["disk"] = d.SizeGBs
+		//net["disk_id"] = d.ID
+		att = append(att, net)
+	}
+
+	return att
 }

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -39,7 +39,7 @@ func expandVirtualServerNetworks(p []interface{}) []vm.Network {
 func expandVirtualServerDisks(p []interface{}) []vm.Disk {
 	disks := make([]vm.Disk, len(p))
 
-	for _, elem := range p {
+	for i, elem := range p {
 		in := elem.(map[string]interface{})
 		disk := vm.Disk{}
 
@@ -53,7 +53,7 @@ func expandVirtualServerDisks(p []interface{}) []vm.Disk {
 			disk.ID = v.(int)
 		}
 
-		disks = append(disks, disk)
+		disks[i] = disk
 	}
 
 	return disks
@@ -271,12 +271,12 @@ func flattenVirtualServerInfo(in *info.Info) []interface{} {
 func flattenVirtualServerDisks(in []vm.Disk) []interface{} {
 	att := make([]interface{}, len(in))
 
-	for _, d := range in {
+	for i, d := range in {
 		net := map[string]interface{}{}
 		net["disk_type"] = d.Type
 		net["disk_gb"] = d.SizeGBs
 		net["disk_id"] = d.ID
-		att = append(att, net)
+		att[i] = net
 	}
 
 	return att

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -37,10 +37,7 @@ func expandVirtualServerNetworks(p []interface{}) []vm.Network {
 }
 
 func expandVirtualServerDisks(p []interface{}) []vm.Disk {
-	var disks []vm.Disk
-	if len(p) < 1 {
-		return disks
-	}
+	disks := make([]vm.Disk, len(p))
 
 	for _, elem := range p {
 		in := elem.(map[string]interface{})
@@ -272,10 +269,7 @@ func flattenVirtualServerInfo(in *info.Info) []interface{} {
 }
 
 func flattenVirtualServerDisks(in []vm.Disk) []interface{} {
-	att := []interface{}{}
-	if len(in) < 1 {
-		return att
-	}
+	att := make([]interface{}, len(in))
 
 	for _, d := range in {
 		net := map[string]interface{}{}

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -49,7 +49,7 @@ func expandVirtualServerDisks(p []interface{}) []vm.Disk {
 		if v, ok := in["disk_type"]; ok {
 			disk.Type = v.(string)
 		}
-		if v, ok := in["disk"]; ok {
+		if v, ok := in["disk_gb"]; ok {
 			disk.SizeGBs = v.(int)
 		}
 		if v, ok := in["disk_id"]; ok {
@@ -280,7 +280,7 @@ func flattenVirtualServerDisks(in []vm.Disk) []interface{} {
 	for _, d := range in {
 		net := map[string]interface{}{}
 		net["disk_type"] = d.Type
-		net["disk"] = d.SizeGBs
+		net["disk_gb"] = d.SizeGBs
 		net["disk_id"] = d.ID
 		att = append(att, net)
 	}

--- a/anxcloud/struct_virtual_server_test.go
+++ b/anxcloud/struct_virtual_server_test.go
@@ -101,6 +101,33 @@ func TestExpanderVirtualServerDNS(t *testing.T) {
 	}
 }
 
+func TestExpanderVirtualServerDisks(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput []vm.Disk
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"disk":      10,
+					"disk_id":   2000,
+					"disk_type": "STD1",
+				},
+			},
+			[]vm.Disk{
+				{ID: 2000, Type: "STD1", SizeGBs: 10},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandVirtualServerDisks(tc.Input)
+		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
+			t.Fatalf("Unexpected output from expander: mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
+
 func TestExpanderVirtualServerInfo(t *testing.T) {
 	cases := []struct {
 		Input          []interface{}
@@ -328,6 +355,37 @@ func TestFlattenVirtualServerInfo(t *testing.T) {
 
 	for _, tc := range cases {
 		output := flattenVirtualServerInfo(&tc.Input)
+		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
+			t.Fatalf("Unexpected output from expander: mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func TestFlattenVirtualServerDisks(t *testing.T) {
+	cases := []struct {
+		Input          []vm.Disk
+		ExpectedOutput []interface{}
+	}{
+		{
+			[]vm.Disk{
+				{
+					ID:      2000,
+					Type:    "STD1",
+					SizeGBs: 10,
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"disk_id":   2000,
+					"disk_type": "STD1",
+					"disk":      10,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenVirtualServerDisks(tc.Input)
 		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
 			t.Fatalf("Unexpected output from expander: mismatch (-want +got):\n%s", diff)
 		}

--- a/anxcloud/struct_virtual_server_test.go
+++ b/anxcloud/struct_virtual_server_test.go
@@ -109,7 +109,7 @@ func TestExpanderVirtualServerDisks(t *testing.T) {
 		{
 			[]interface{}{
 				map[string]interface{}{
-					"disk":      10,
+					"disk_gb":   10,
 					"disk_id":   2000,
 					"disk_type": "STD1",
 				},
@@ -378,7 +378,7 @@ func TestFlattenVirtualServerDisks(t *testing.T) {
 				map[string]interface{}{
 					"disk_id":   2000,
 					"disk_type": "STD1",
-					"disk":      10,
+					"disk_gb":   10,
 				},
 			},
 		},

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -21,7 +21,6 @@ resource "anxcloud_virtual_server" "example" {
   template_type = "templates"
 
   cpus     = 4
-  disk     = 50
   memory   = 4096
   password = "flatcar#1234$%"
 
@@ -38,6 +37,13 @@ resource "anxcloud_virtual_server" "example" {
     nic_type = "vmxnet3"
   }
 
+  disks {
+    disk: 100
+  }
+
+  disks {
+    disk: 200
+  }
 
   dns = ["8.8.8.8"]
 }
@@ -53,8 +59,6 @@ resource "anxcloud_virtual_server" "example" {
 - `cpu_performance_type` - (Optional) CPU type. Example: `best-effort`, `standard`, `enterprise`, `performance`, defaults to `standard`.
 - `sockets` - (Optional) Amount of CPU sockets Number of cores have to be a multiple of sockets, as they will be spread evenly across all sockets. Defaults to number of cores, i.e. one socket per CPU core.
 - `memory` - (Required) Memory in MB.
-- `disk` - (Required) Requested disk capacity in GB.
-- `disk_type` - (Optional) Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.
 - `network` - (Optional) Network interface. See [network](#network) below for details. 
 - `dns` - (Optional) DNS configuration. Maximum items 4. Defaults to template settings.
 - `password` (Required) Plaintext password. Example: ('!anx123mySuperStrongPassword123anx!', 'go3ju0la1ro3', …). USE IT AT YOUR OWN RISK! (or SSH key instead).
@@ -71,6 +75,11 @@ resource "anxcloud_virtual_server" "example" {
 - `vlan_id` - (Required) VLAN identifier.
 - `nic_type` - (Required) Network interface card type.
 - `ips` - (Optional) Requested list of IPs and IPs identifiers. IPs are ignored when using template_type 'from_scratch'. Defaults to free IPs from IP pool attached to VLAN.
+
+### Disks
+
+- `disk` - (Required) Disk size in GB.
+- `disk_type` - (Optional) Storage type for this disk. Default as per datacenter.
 
 ## Attributes Reference
 

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -37,10 +37,12 @@ resource "anxcloud_virtual_server" "example" {
     nic_type = "vmxnet3"
   }
 
+  # Disk 1
   disks {
     disk_gb: 100
   }
 
+  # Disk 2
   disks {
     disk_gb: 200
   }

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -38,11 +38,11 @@ resource "anxcloud_virtual_server" "example" {
   }
 
   disks {
-    disk: 100
+    disk_gb: 100
   }
 
   disks {
-    disk: 200
+    disk_gb: 200
   }
 
   dns = ["8.8.8.8"]

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -78,7 +78,7 @@ resource "anxcloud_virtual_server" "example" {
 
 ### Disks
 
-- `disk` - (Required) Disk size in GB.
+- `disk_gb` - (Required) Disk size in GB.
 - `disk_type` - (Optional) Storage type for this disk. Default as per datacenter.
 
 ## Attributes Reference

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -39,12 +39,12 @@ resource "anxcloud_virtual_server" "example" {
 
   # Disk 1
   disks {
-    disk_gb: 100
+    disk_gb = 100
   }
 
   # Disk 2
   disks {
-    disk_gb: 200
+    disk_gb = 200
   }
 
   dns = ["8.8.8.8"]

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -59,6 +59,8 @@ resource "anxcloud_virtual_server" "example" {
 - `cpu_performance_type` - (Optional) CPU type. Example: `best-effort`, `standard`, `enterprise`, `performance`, defaults to `standard`.
 - `sockets` - (Optional) Amount of CPU sockets Number of cores have to be a multiple of sockets, as they will be spread evenly across all sockets. Defaults to number of cores, i.e. one socket per CPU core.
 - `memory` - (Required) Memory in MB.
+- `disk` - (Optional) Requested disk capacity in GB. (This will be overwritten if at least one disk is supplied via `disks`)
+- `disk_type` - (Optional) Requested disk category (limits disk performance, e.g. IOPS). Default as defined by data center.
 - `network` - (Optional) Network interface. See [network](#network) below for details. 
 - `dns` - (Optional) DNS configuration. Maximum items 4. Defaults to template settings.
 - `password` (Required) Plaintext password. Example: ('!anx123mySuperStrongPassword123anx!', 'go3ju0la1ro3', …). USE IT AT YOUR OWN RISK! (or SSH key instead).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/anexia-it/terraform-provider-anxcloud
 go 1.14
 
 require (
-	github.com/anexia-it/go-anxcloud v0.3.17
+	github.com/anexia-it/go-anxcloud v0.3.18
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/google/go-cmp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/anexia-it/terraform-provider-anxcloud
 go 1.14
 
 require (
-	github.com/anexia-it/go-anxcloud v0.3.16
+	github.com/anexia-it/go-anxcloud v0.3.17
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -40,10 +40,6 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/anexia-it/go-anxcloud v0.3.16 h1:zFYNqdYoQlgCGOMOnkC3mi/owvM/z+fUxfzpaPAj4O4=
-github.com/anexia-it/go-anxcloud v0.3.16/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
-github.com/anexia-it/go-anxcloud v0.3.17 h1:iFvWI5WaDsOpRIQQZ9JUjYQCrjFNxe4asvfAieiPmIM=
-github.com/anexia-it/go-anxcloud v0.3.17/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anexia-it/go-anxcloud v0.3.18 h1:Gcd+6rGe5/eNFAIl4SmMBNXFJJXEVv82dSdSqvzAeOM=
 github.com/anexia-it/go-anxcloud v0.3.18/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/anexia-it/go-anxcloud v0.3.16 h1:zFYNqdYoQlgCGOMOnkC3mi/owvM/z+fUxfzp
 github.com/anexia-it/go-anxcloud v0.3.16/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anexia-it/go-anxcloud v0.3.17 h1:iFvWI5WaDsOpRIQQZ9JUjYQCrjFNxe4asvfAieiPmIM=
 github.com/anexia-it/go-anxcloud v0.3.17/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
+github.com/anexia-it/go-anxcloud v0.3.18 h1:Gcd+6rGe5/eNFAIl4SmMBNXFJJXEVv82dSdSqvzAeOM=
+github.com/anexia-it/go-anxcloud v0.3.18/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBb
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anexia-it/go-anxcloud v0.3.16 h1:zFYNqdYoQlgCGOMOnkC3mi/owvM/z+fUxfzpaPAj4O4=
 github.com/anexia-it/go-anxcloud v0.3.16/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
+github.com/anexia-it/go-anxcloud v0.3.17 h1:iFvWI5WaDsOpRIQQZ9JUjYQCrjFNxe4asvfAieiPmIM=
+github.com/anexia-it/go-anxcloud v0.3.17/go.mod h1:g78/+Db9XeiVS+aKqJaq9j7XfxhyXWM8PHY5JRbK9RY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=


### PR DESCRIPTION
### Description

This Pull Request introduces a temparary implementation to support multiple disks when creating or updating a `virtual server`. This is temporary until the backend/API allows to configure multiple disks natively. Until then creating a `virtual server` with multiple disks requires to create it with one disk and then update it with the rest. This is done automatically if `disks` is configured with the plan.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAnxCloudVirtualServer'
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):

```release-note
Added `disks` as possible configuration to provide more than one single disk to a `virtual server`. If provided it will always overrule the default `disk` and `disk_type` configurations.
```

### References
None

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
