### PR TITLE
Remove base64 requirement from doc

### DIFF
--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -68,7 +68,7 @@ resource "anxcloud_virtual_server" "example" {
 - `dns` - (Optional) DNS configuration. Maximum items 4. Defaults to template settings.
 - `password` (Required) Plaintext password. Example: ('!anx123mySuperStrongPassword123anx!', 'go3ju0la1ro3', …). USE IT AT YOUR OWN RISK! (or SSH key instead).
 - `ssh_key` - (Required) Public key (instead of password, only for Linux systems). Recommended over providing a plaintext password.
-- `script` - (Optional) Script to be executed after provisioning. Should be base64 encoded. Consider the corresponding shebang at the beginning of your script. If you want to use PowerShell, the first line should be: #ps1_sysnative.
+- `script` - (Optional) Script to be executed after provisioning. Consider the corresponding shebang at the beginning of your script. If you want to use PowerShell, the first line should be: #ps1_sysnative.
 - `boot_delay` - (Optional) Boot delay in seconds. Example: (0, 1, …).
 - `enter_bios_setup` - (Optional) Start the VM into BIOS setup on next boot. Defaults to false.
 - `force_restart_if_needed` - (Optional) Certain operations may only be performed in powered off stat. Such as: shrinking memory, shrinking/adding cpu, removing disk, scale a disk beyond 2 GB. Passing this value as true will always execute a power offand reboot request after completing all other operations. Without this flag set to true scaling operations requiring a reboot will fail. Defaults to false.


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Removed the "Should be base64 encoded" requirement from the virtual server resource doc.
Acceptance tests are not required for this change.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Updated virtual server resource documentation
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
