### PR TITLE
Add check for prefix failure status

### DIFF
--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	prefixStatusActive  = "Active"
+	prefixStatusFailure = "Failed"
 	prefixStatusDeleted = "Marked for deletion"
 )
 
@@ -62,7 +63,7 @@ func resourceNetworkPrefixCreate(ctx context.Context, d *schema.ResourceData, m 
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("unable to get network prefix with '%s' id", d.Id()))
 		}
-		if pref.Status == prefixStatusActive {
+		if pref.Status == prefixStatusActive || pref.Status == prefixStatusFailure {
 			return nil
 		}
 		return resource.RetryableError(fmt.Errorf("waiting for network prefix with '%s' id to be: %s", d.Id(), prefixStatusActive))


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

<!--- Please leave a helpful description of the pull request here. --->
Adding a check to stop polling the prefix on creation when we see a _Failed_ state. 

### Acceptance tests
We don't have a reliable long-term way of causing this. I have tested it manually.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 - resource/network-prefix: Adding stop condition for Failed state.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
