### PR TITLE
Fix a bug where updating tags hangs until timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.3
+ENHANCEMENTS
+
+* provider: Fix a bug where updating tags hangs until timeout
+
 ## 0.3.2
 ENHANCEMENTS
 

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -517,8 +517,10 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
-	if _, err = provisioningAPI.Progress().AwaitCompletion(ctx, response.Identifier); err != nil {
-		return diag.FromErr(err)
+	if response.Progress != 100 {
+		if _, err = provisioningAPI.Progress().AwaitCompletion(ctx, response.Identifier); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	delay := 10 * time.Second

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -91,7 +91,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmDef, "newTag"),
+				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmAddTag, "newTag"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmAddTag),
 					resource.TestCheckResourceAttr(resourcePath, "tags.0", "newTag"),

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -71,6 +71,13 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmAddTag, "newTag"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmAddTag),
+					resource.TestCheckResourceAttr(resourcePath, "tags.0", "newTag"),
+				),
+			},
+			{
 				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmDefUpscale),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmDefUpscale),
@@ -88,13 +95,6 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "template_id", vmDefDownscale.TemplateID),
 					resource.TestCheckResourceAttr(resourcePath, "cpus", strconv.Itoa(vmDefDownscale.CPUs)),
 					resource.TestCheckResourceAttr(resourcePath, "memory", strconv.Itoa(vmDefDownscale.Memory)),
-				),
-			},
-			{
-				Config: testAccConfigAnxCloudVirtualServer(resourceName, &vmAddTag, "newTag"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAnxCloudVirtualServerExists(resourcePath, &vmAddTag),
-					resource.TestCheckResourceAttr(resourcePath, "tags.0", "newTag"),
 				),
 			},
 			{

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	flag.Parse()
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), "hashicorp.com/anexia-it/anxcloud",
+		err := plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/anxcloud",
 			&plugin.ServeOpts{
 				ProviderFunc: anxcloud.Provider,
 			})

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	flag.Parse()
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/anxcloud",
+		err := plugin.Debug(context.Background(), "hashicorp.com/anexia-it/anxcloud",
 			&plugin.ServeOpts{
 				ProviderFunc: anxcloud.Provider,
 			})


### PR DESCRIPTION
### Description

The Provisioning endpoint returns an non existing identifier when nothing need's to be done, which is the case when only a tag is updated. Due to a bug in the go-anxcloud SDK awaiting a non existing provisioning progress to finish leads to waiting forever until the context times out. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAnxCloudVirtualServer'
2021-08-16T14:47:28.6757930Z ##[group]Run make testacc
2021-08-16T14:47:28.6758479Z [36;1mmake testacc[0m
2021-08-16T14:47:28.6799572Z shell: /usr/bin/bash -e {0}
2021-08-16T14:47:28.6800031Z env:
2021-08-16T14:47:28.6800801Z   ANEXIA_TOKEN: ***
2021-08-16T14:47:28.6801257Z ##[endgroup]
2021-08-16T14:47:29.2355357Z ==> Checking that code complies with gofmt requirements...
2021-08-16T14:47:29.4422938Z TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -v  -timeout 120m -parallel=4
2021-08-16T14:47:30.5228075Z go: downloading github.com/anexia-it/go-anxcloud v0.3.21
2021-08-16T14:47:30.5249239Z go: downloading github.com/hashicorp/go-multierror v1.1.0
2021-08-16T14:47:30.5375224Z go: downloading github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
2021-08-16T14:47:31.1991898Z go: downloading github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
2021-08-16T14:47:31.1993438Z go: downloading github.com/hashicorp/errwrap v1.0.0
2021-08-16T14:47:31.1994574Z go: downloading github.com/mitchellh/go-testing-interface v1.0.4
2021-08-16T14:47:31.1995905Z go: downloading github.com/hashicorp/go-uuid v1.0.1
2021-08-16T14:47:31.1996610Z go: downloading github.com/mitchellh/copystructure v1.2.0
2021-08-16T14:47:31.1997578Z go: downloading github.com/hashicorp/terraform-plugin-go v0.3.0
2021-08-16T14:47:31.1998371Z go: downloading github.com/mitchellh/mapstructure v1.1.2
2021-08-16T14:47:31.1999128Z go: downloading github.com/vmihailenco/msgpack v4.0.4+incompatible
2021-08-16T14:47:31.1999887Z go: downloading google.golang.org/grpc v1.32.0
2021-08-16T14:47:31.2000733Z go: downloading github.com/hashicorp/terraform-json v0.12.0
2021-08-16T14:47:31.2001581Z go: downloading github.com/hashicorp/go-hclog v0.15.0
2021-08-16T14:47:31.2002359Z go: downloading github.com/mattn/go-isatty v0.0.12
2021-08-16T14:47:31.2003111Z go: downloading github.com/zclconf/go-cty v1.8.4
2021-08-16T14:47:31.2003902Z go: downloading golang.org/x/net v0.0.0-20210326060303-6b1517762897
2021-08-16T14:47:31.2004523Z go: downloading github.com/fatih/color v1.10.0
2021-08-16T14:47:31.2005125Z go: downloading github.com/golang/protobuf v1.4.2
2021-08-16T14:47:31.2005752Z go: downloading github.com/hashicorp/hcl/v2 v2.6.0
2021-08-16T14:47:31.2006958Z go: downloading github.com/mitchellh/reflectwalk v1.0.2
2021-08-16T14:47:31.2317667Z go: downloading github.com/davecgh/go-spew v1.1.1
2021-08-16T14:47:31.2692419Z go: downloading github.com/hashicorp/terraform-exec v0.14.0
2021-08-16T14:47:31.2807338Z go: downloading google.golang.org/protobuf v1.25.0
2021-08-16T14:47:32.1967560Z go: downloading github.com/hashicorp/go-version v1.3.0
2021-08-16T14:47:32.2091853Z go: downloading golang.org/x/text v0.3.5
2021-08-16T14:47:32.2095005Z go: downloading github.com/apparentlymart/go-textseg v1.0.0
2021-08-16T14:47:32.2097068Z go: downloading github.com/apparentlymart/go-textseg/v12 v12.0.0
2021-08-16T14:47:32.2098847Z go: downloading golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79
2021-08-16T14:47:32.2100396Z go: downloading github.com/agext/levenshtein v1.2.2
2021-08-16T14:47:32.2102449Z go: downloading google.golang.org/genproto v0.0.0-20200711021454-869866162049
2021-08-16T14:47:32.2105284Z go: downloading github.com/hashicorp/go-plugin v1.4.1
2021-08-16T14:47:32.2107394Z go: downloading github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
2021-08-16T14:47:32.2108977Z go: downloading github.com/hashicorp/logutils v1.0.0
2021-08-16T14:47:32.2111448Z go: downloading github.com/mitchellh/go-wordwrap v1.0.0
2021-08-16T14:47:32.2113903Z go: downloading github.com/apparentlymart/go-textseg/v13 v13.0.0
2021-08-16T14:47:32.2115756Z go: downloading github.com/hashicorp/go-checkpoint v0.5.0
2021-08-16T14:47:32.2117468Z go: downloading github.com/hashicorp/go-cleanhttp v0.5.2
2021-08-16T14:47:32.2118713Z go: downloading github.com/hashicorp/go-getter v1.5.3
2021-08-16T14:47:32.2120121Z go: downloading golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
2021-08-16T14:47:32.2121643Z go: downloading github.com/aws/aws-sdk-go v1.25.3
2021-08-16T14:47:32.2122962Z go: downloading github.com/mattn/go-colorable v0.1.8
2021-08-16T14:47:32.2125240Z go: downloading github.com/hashicorp/go-safetemp v1.0.0
2021-08-16T14:47:32.2126318Z go: downloading github.com/ulikunitz/xz v0.5.8
2021-08-16T14:47:32.2127584Z go: downloading google.golang.org/api v0.29.0
2021-08-16T14:47:32.2957537Z go: downloading github.com/mitchellh/go-homedir v1.1.0
2021-08-16T14:47:33.0488603Z go: downloading github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
2021-08-16T14:47:33.1196642Z go: downloading cloud.google.com/go v0.61.0
2021-08-16T14:47:33.2303586Z go: downloading github.com/oklog/run v1.0.0
2021-08-16T14:47:33.5001771Z go: downloading github.com/klauspost/compress v1.11.2
2021-08-16T14:47:33.6451074Z go: downloading cloud.google.com/go/storage v1.10.0
2021-08-16T14:47:35.2716560Z go: downloading github.com/googleapis/gax-go/v2 v2.0.5
2021-08-16T14:47:35.2869574Z go: downloading go.opencensus.io v0.22.4
2021-08-16T14:47:35.3403719Z go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
2021-08-16T14:47:35.4242339Z go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
2021-08-16T14:47:35.7489902Z go: downloading golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
2021-08-16T14:47:36.4244609Z go: downloading github.com/lithammer/shortuuid v3.0.0+incompatible
2021-08-16T14:47:36.4535201Z go: downloading github.com/google/go-cmp v0.5.6
2021-08-16T14:47:36.6017629Z go: downloading github.com/google/uuid v1.1.2
2021-08-16T14:48:06.6972388Z ?   	github.com/anexia-it/terraform-provider-anxcloud	[no test files]
2021-08-16T15:24:25.7406458Z === RUN   TestAccAnxCloudCoreLocationsDataSource
2021-08-16T15:24:25.7408457Z --- PASS: TestAccAnxCloudCoreLocationsDataSource (11.60s)
2021-08-16T15:24:25.7409937Z === RUN   TestAccAnxCloudCPUPerformanceTypesDataSource
2021-08-16T15:24:25.7411545Z --- PASS: TestAccAnxCloudCPUPerformanceTypesDataSource (3.50s)
2021-08-16T15:24:25.7412735Z === RUN   TestAccAnxCloudDiskTypeDataSource
2021-08-16T15:24:25.7413853Z --- PASS: TestAccAnxCloudDiskTypeDataSource (4.29s)
2021-08-16T15:24:25.7414949Z === RUN   TestAccAnxCloudIPAddressesDataSource
2021-08-16T15:24:25.7416161Z --- PASS: TestAccAnxCloudIPAddressesDataSource (5.47s)
2021-08-16T15:24:25.7417197Z === RUN   TestAccAnxCloudNICTypesDataSource
2021-08-16T15:24:25.7418302Z --- PASS: TestAccAnxCloudNICTypesDataSource (3.64s)
2021-08-16T15:24:25.7419211Z === RUN   TestAccAnxCloudTagsDataSource
2021-08-16T15:24:25.7420202Z --- PASS: TestAccAnxCloudTagsDataSource (3.56s)
2021-08-16T15:24:25.7421107Z === RUN   TestAccAnxCloudTemplateDataSource
2021-08-16T15:24:25.7422221Z --- PASS: TestAccAnxCloudTemplateDataSource (6.07s)
2021-08-16T15:24:25.7423144Z === RUN   TestAccAnxCloudVLANsDataSource
2021-08-16T15:24:25.7424160Z --- PASS: TestAccAnxCloudVLANsDataSource (4.15s)
2021-08-16T15:24:25.7425241Z === RUN   TestAccAnxCloudVSphereLocationsDataSource
2021-08-16T15:24:25.7426648Z --- PASS: TestAccAnxCloudVSphereLocationsDataSource (5.49s)
2021-08-16T15:24:25.7427524Z === RUN   TestProvider
2021-08-16T15:24:25.7428102Z --- PASS: TestProvider (0.00s)
2021-08-16T15:24:25.7428563Z === RUN   TestProvider_impl
2021-08-16T15:24:25.7429173Z --- PASS: TestProvider_impl (0.00s)
2021-08-16T15:24:25.7429754Z === RUN   TestAccAnxCloudIPAddress
2021-08-16T15:24:25.7430618Z --- PASS: TestAccAnxCloudIPAddress (24.95s)
2021-08-16T15:24:25.7431449Z === RUN   TestAccAnxCloudIPAddressReserved
2021-08-16T15:24:25.7432522Z --- PASS: TestAccAnxCloudIPAddressReserved (24.69s)
2021-08-16T15:24:25.7433406Z === RUN   TestAccAnxCloudNetworkPrefix
2021-08-16T15:24:25.7434343Z --- PASS: TestAccAnxCloudNetworkPrefix (90.79s)
2021-08-16T15:24:25.7435035Z === RUN   TestAccAnxCloudTag
2021-08-16T15:24:25.7435801Z --- PASS: TestAccAnxCloudTag (4.84s)
2021-08-16T15:24:25.7436481Z === RUN   TestAccAnxCloudVirtualServer
2021-08-16T15:24:25.7437443Z --- PASS: TestAccAnxCloudVirtualServer (789.87s)
2021-08-16T15:24:25.7438547Z === RUN   TestAccAnxCloudVirtualServerMultiDiskScaling
2021-08-16T15:24:25.7439966Z === RUN   TestAccAnxCloudVirtualServerMultiDiskScaling/AddDisk
2021-08-16T15:24:25.7441666Z === RUN   TestAccAnxCloudVirtualServerMultiDiskScaling/ChangeAddDisk
2021-08-16T15:24:25.7443305Z === RUN   TestAccAnxCloudVirtualServerMultiDiskScaling/MultiDiskTemplateChange
2021-08-16T15:24:25.7445066Z --- PASS: TestAccAnxCloudVirtualServerMultiDiskScaling (1097.83s)
2021-08-16T15:24:25.7446723Z     --- PASS: TestAccAnxCloudVirtualServerMultiDiskScaling/AddDisk (345.39s)
2021-08-16T15:24:25.7448557Z     --- PASS: TestAccAnxCloudVirtualServerMultiDiskScaling/ChangeAddDisk (376.02s)
2021-08-16T15:24:25.7450452Z     --- PASS: TestAccAnxCloudVirtualServerMultiDiskScaling/MultiDiskTemplateChange (376.43s)
2021-08-16T15:24:25.7451634Z === RUN   TestAccAnxCloudVLAN
2021-08-16T15:24:25.7452332Z --- PASS: TestAccAnxCloudVLAN (96.13s)
2021-08-16T15:24:25.7453088Z === RUN   TestFlattenCPUPerfrormanceTypes
2021-08-16T15:24:25.7454134Z --- PASS: TestFlattenCPUPerfrormanceTypes (0.00s)
2021-08-16T15:24:25.7454904Z === RUN   TestFlattenDiskTypes
2021-08-16T15:24:25.7455643Z --- PASS: TestFlattenDiskTypes (0.00s)
2021-08-16T15:24:25.7456261Z === RUN   TestFlattenIPAddresses
2021-08-16T15:24:25.7457040Z --- PASS: TestFlattenIPAddresses (0.00s)
2021-08-16T15:24:25.7457705Z === RUN   TestFlattenCoreLocations
2021-08-16T15:24:25.7458526Z --- PASS: TestFlattenCoreLocations (0.00s)
2021-08-16T15:24:25.7459357Z === RUN   TestFlattenNetworkPrefixLocations
2021-08-16T15:24:25.7460449Z --- PASS: TestFlattenNetworkPrefixLocations (0.00s)
2021-08-16T15:24:25.7461278Z === RUN   TestFlattenVLANLocations
2021-08-16T15:24:25.7462092Z --- PASS: TestFlattenVLANLocations (0.00s)
2021-08-16T15:24:25.7462745Z === RUN   TestFlattenLocations
2021-08-16T15:24:25.7463460Z --- PASS: TestFlattenLocations (0.00s)
2021-08-16T15:24:25.7463998Z === RUN   TestFlattenTags
2021-08-16T15:24:25.7464614Z --- PASS: TestFlattenTags (0.00s)
2021-08-16T15:24:25.7465151Z === RUN   TestFlattenTemplates
2021-08-16T15:24:25.7465884Z --- PASS: TestFlattenTemplates (0.00s)
2021-08-16T15:24:25.7466671Z === RUN   TestExpanderVirtualServerNetworks
2021-08-16T15:24:25.7467769Z --- PASS: TestExpanderVirtualServerNetworks (0.00s)
2021-08-16T15:24:25.7468674Z === RUN   TestExpanderVirtualServerDNS
2021-08-16T15:24:25.7469608Z --- PASS: TestExpanderVirtualServerDNS (0.00s)
2021-08-16T15:24:25.7470463Z === RUN   TestExpanderVirtualServerDisks
2021-08-16T15:24:25.7471476Z --- PASS: TestExpanderVirtualServerDisks (0.00s)
2021-08-16T15:24:25.7472332Z === RUN   TestExpanderVirtualServerInfo
2021-08-16T15:24:25.7473311Z --- PASS: TestExpanderVirtualServerInfo (0.00s)
2021-08-16T15:24:25.7474187Z === RUN   TestFlattenVirtualServerNetwork
2021-08-16T15:24:25.7475206Z --- PASS: TestFlattenVirtualServerNetwork (0.00s)
2021-08-16T15:24:25.7476474Z === RUN   TestFlattenVirtualServerInfo
2021-08-16T15:24:25.7477724Z --- PASS: TestFlattenVirtualServerInfo (0.00s)
2021-08-16T15:24:25.7478671Z === RUN   TestFlattenVirtualServerDisks
2021-08-16T15:24:25.7479879Z --- PASS: TestFlattenVirtualServerDisks (0.00s)
2021-08-16T15:24:25.7480669Z === RUN   TestRoundDiskSize
2021-08-16T15:24:25.7481479Z --- PASS: TestRoundDiskSize (0.00s)
2021-08-16T15:24:25.7482102Z === RUN   TestFlattenVLANs
2021-08-16T15:24:25.7482887Z --- PASS: TestFlattenVLANs (0.00s)
2021-08-16T15:24:25.7483323Z PASS
2021-08-16T15:24:25.7484346Z ok  	github.com/anexia-it/terraform-provider-anxcloud/anxcloud	2176.903s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
Fix a bug where updating tags hangs until timeout
-->

```release-note
Fix a bug where updating tags hangs until timeout
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
