### PR TITLE
check for empty vlan

### DIFF
--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -123,7 +123,10 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 	if err := d.Set("router_redundancy", info.RouterRedundancy); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if err := d.Set("vlan_id", info.Vlans[0].ID); err != nil {
+
+	if len(info.Vlans) == 0 {
+		diags = append(diags, diag.Errorf("no VLAN seems to be attached to prefix '%s'", info.ID)...)
+	} else if err := d.Set("vlan_id", info.Vlans[0].ID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 


### PR DESCRIPTION
### Description

Fix SYSENG-516.
Check whether the VLAN slice is empty before accessing it.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
