### PR TITLE
Fix VLAN update leads to vm_provisioning flakiness

### DIFF
--- a/anxcloud/resource_vlan.go
+++ b/anxcloud/resource_vlan.go
@@ -126,9 +126,8 @@ func resourceVLANUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	if d.HasChange("description_customer") {
 		def.CustomerDescription = d.Get("description_customer").(string)
 	}
-	if d.HasChange("vm_provisioning") {
-		def.VMProvisioning = d.Get("vm_provisioning").(bool)
-	}
+	def.VMProvisioning = d.Get("vm_provisioning").(bool)
+
 	if err := vlanAPI.Update(ctx, d.Id(), def); err != nil {
 		return diag.FromErr(err)
 	}

--- a/anxcloud/resource_vlan_test.go
+++ b/anxcloud/resource_vlan_test.go
@@ -28,12 +28,11 @@ func TestAccAnxCloudVLAN(t *testing.T) {
 		CheckDestroy:      testAccCheckAnxCloudVLANDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescription, false),
+				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescription, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
-					resource.TestCheckResourceAttr(resourcePath, "vm_provisioning", "false"),
 					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescription),
-					testAccCheckAnxCloudVLANExists(resourcePath, customerDescription, false),
+					testAccCheckAnxCloudVLANExists(resourcePath, customerDescription, true),
 				),
 			},
 			{
@@ -42,7 +41,14 @@ func TestAccAnxCloudVLAN(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
 					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
 					testAccCheckAnxCloudVLANExists(resourcePath, customerDescriptionUpdate, true),
-					resource.TestCheckResourceAttr(resourcePath, "vm_provisioning", "true"),
+				),
+			},
+			{
+				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescriptionUpdate, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
+					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
+					testAccCheckAnxCloudVLANExists(resourcePath, customerDescriptionUpdate, false),
 				),
 			},
 			{

--- a/anxcloud/resource_vlan_test.go
+++ b/anxcloud/resource_vlan_test.go
@@ -36,19 +36,19 @@ func TestAccAnxCloudVLAN(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescriptionUpdate, true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
-					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
-					testAccCheckAnxCloudVLANExists(resourcePath, customerDescriptionUpdate, true),
-				),
-			},
-			{
 				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescriptionUpdate, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
 					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
 					testAccCheckAnxCloudVLANExists(resourcePath, customerDescriptionUpdate, false),
+				),
+			},
+			{
+				Config: testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescriptionUpdate, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "location_id", locationID),
+					resource.TestCheckResourceAttr(resourcePath, "description_customer", customerDescriptionUpdate),
+					testAccCheckAnxCloudVLANExists(resourcePath, customerDescriptionUpdate, true),
 				),
 			},
 			{


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/anxcloud_vlan - remove a bug where updating a VLAN leads to `vm_provisioning` flakiness.
```

### References

* **SYSENG-415**

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
