### PR TITLE
vsphere integration tests: template name prefix

### DIFF
--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -3,8 +3,6 @@ package anxcloud
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/templates"
 	"log"
 	"os"
 	"regexp"
@@ -13,11 +11,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/lithammer/shortuuid"
+
 	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vsphere"
+	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/templates"
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/vm"
 )
 
@@ -483,7 +485,7 @@ func vsphereAccTestInit(locationID string, templateName string) string {
 
 	selected := make([]templates.Template, 0, 1)
 	for _, tpl := range tpls {
-		if tpl.Name == templateName {
+		if strings.HasPrefix(tpl.Name, templateName) {
 			selected = append(selected, tpl)
 		}
 	}


### PR DESCRIPTION
### Description

We search templates by full name match. Since the version is part of the
name, this changes the logic to select templates with name prefix. See
[SYSENG-866](https://ats.anexia-it.com/browse/SYSENG-866) for details.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use the following format:
 * <resource-type>[/<resource-name>] - <short description of what has been done>

where resource-type can be something like 'resource', 'data', 'all resources', '**New Resource**', '**New Datasource**' 

e.g.

* resource/anxcloud_ip_address - fix IP address cleanup
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
* [SYSENG-866](https://ats.anexia-it.com/browse/SYSENG-866)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
