### PR TITLE
Add generic API from go-anxcloud to provider context

### DIFF
--- a/anxcloud/data_source_core_locations.go
+++ b/anxcloud/data_source_core_locations.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/core/location"
 )
 
@@ -19,7 +18,7 @@ func dataSourceCoreLocations() *schema.Resource {
 }
 
 func dataSourceCoreLocationsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	l := location.NewAPI(c)
 
 	locations, err := l.List(ctx, d.Get("page").(int), d.Get("limit").(int), d.Get("search").(string))

--- a/anxcloud/data_source_cpu_performance_types.go
+++ b/anxcloud/data_source_cpu_performance_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 
 	cpuperformancetypes "go.anx.io/go-anxcloud/pkg/vsphere/provisioning/cpuperformancetypes"
 )
@@ -20,7 +19,7 @@ func dataSourceCPUPerformanceTypes() *schema.Resource {
 }
 
 func dataSourceCPUPerformanceTypesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	api := cpuperformancetypes.NewAPI(c)
 
 	types, err := api.List(ctx)

--- a/anxcloud/data_source_disk_types.go
+++ b/anxcloud/data_source_disk_types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/disktype"
 )
 
@@ -17,7 +16,7 @@ func dataSourceDiskTypes() *schema.Resource {
 }
 
 func dataSourceDiskTypesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	t := disktype.NewAPI(c)
 	locationID := d.Get("location_id").(string)
 	diskTypes, err := t.List(ctx, locationID, 0, 1000)

--- a/anxcloud/data_source_dns_records.go
+++ b/anxcloud/data_source_dns_records.go
@@ -2,9 +2,9 @@ package anxcloud
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/clouddns/zone"
 )
 
@@ -16,7 +16,7 @@ func dataSourceDNSRecords() *schema.Resource {
 }
 
 func dataSourceDNSRecordsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := zone.NewAPI(c)
 
 	zoneName := d.Get("zone_name").(string)

--- a/anxcloud/data_source_dns_zones.go
+++ b/anxcloud/data_source_dns_zones.go
@@ -2,12 +2,12 @@ package anxcloud
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
-	"go.anx.io/go-anxcloud/pkg/clouddns/zone"
 	"strconv"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.anx.io/go-anxcloud/pkg/clouddns/zone"
 )
 
 func datasourceDNSZones() *schema.Resource {
@@ -18,7 +18,7 @@ func datasourceDNSZones() *schema.Resource {
 }
 
 func dataSourceDNSZonesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := zone.NewAPI(c)
 
 	zones, err := a.List(ctx)

--- a/anxcloud/data_source_ips.go
+++ b/anxcloud/data_source_ips.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/address"
 )
 
@@ -19,7 +18,7 @@ func dataSourceIPAddresses() *schema.Resource {
 }
 
 func dataSourceIPAddressesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := address.NewAPI(c)
 
 	addresses, err := a.List(ctx, d.Get("page").(int), d.Get("limit").(int), d.Get("search").(string))

--- a/anxcloud/data_source_nic_type.go
+++ b/anxcloud/data_source_nic_type.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/nictype"
 )
 
@@ -19,7 +18,7 @@ func dataSourceNICTypes() *schema.Resource {
 }
 
 func dataSourceNICTypesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	n := nictype.NewAPI(c)
 
 	nicTypes, err := n.List(ctx)

--- a/anxcloud/data_source_tags.go
+++ b/anxcloud/data_source_tags.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/core/tags"
 )
 
@@ -20,7 +19,7 @@ func dataSourceTags() *schema.Resource {
 }
 
 func dataSourceTagsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	tagsAPI := tags.NewAPI(c)
 
 	page := d.Get("page").(int)

--- a/anxcloud/data_source_template.go
+++ b/anxcloud/data_source_template.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/templates"
 )
 
@@ -17,7 +16,7 @@ func dataSourceTemplate() *schema.Resource {
 }
 
 func dataSourceTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	t := templates.NewAPI(c)
 	locationID := d.Get("location_id").(string)
 	templateType := d.Get("template_type").(string)

--- a/anxcloud/data_source_vlans.go
+++ b/anxcloud/data_source_vlans.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vlan"
 )
 
@@ -19,7 +18,7 @@ func dataSourceVLANs() *schema.Resource {
 }
 
 func dataSourceVLANsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	v := vlan.NewAPI(c)
 
 	vlans, err := v.List(ctx, d.Get("page").(int), d.Get("limit").(int), d.Get("search").(string))

--- a/anxcloud/data_source_vsphere_locations.go
+++ b/anxcloud/data_source_vsphere_locations.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/location"
 )
@@ -21,7 +20,7 @@ func dataSourceVSphereLocations() *schema.Resource {
 }
 
 func dataSourceVSphereLocationsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	api := location.NewAPI(c)
 
 	page := d.Get("page").(int)

--- a/anxcloud/provider.go
+++ b/anxcloud/provider.go
@@ -86,8 +86,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Unable to create generic Anexia API",
-			Detail:   "Unable to create generic Anexia API with the given token, either the token is empty or invalid",
+			Summary:  "Unable to create generic Anexia client",
+			Detail:   "Unable to create generic Anexia client with the given token, either the token is empty or invalid",
 		})
 		return nil, diags
 	}

--- a/anxcloud/provider.go
+++ b/anxcloud/provider.go
@@ -86,8 +86,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Unable to create Anexia client",
-			Detail:   "Unable to create Anexia client with the given token, either the token is empty or invalid",
+			Summary:  "Unable to create generic Anexia API",
+			Detail:   "Unable to create generic Anexia API with the given token, either the token is empty or invalid",
 		})
 		return nil, diags
 	}

--- a/anxcloud/resource_ip_address.go
+++ b/anxcloud/resource_ip_address.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/address"
 )
 
@@ -38,7 +37,7 @@ func resourceIPAddress() *schema.Resource {
 }
 
 func resourceIPAddressCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := address.NewAPI(c)
 	prefixID := d.Get("network_prefix_id").(string)
 
@@ -75,7 +74,7 @@ func resourceIPAddressCreate(ctx context.Context, d *schema.ResourceData, m inte
 func resourceIPAddressRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags []diag.Diagnostic
 
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := address.NewAPI(c)
 
 	info, err := a.Get(ctx, d.Id())
@@ -117,7 +116,7 @@ func resourceIPAddressRead(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceIPAddressUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := address.NewAPI(c)
 
 	if !d.HasChanges("description_customer", "role") {
@@ -136,7 +135,7 @@ func resourceIPAddressUpdate(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func resourceIPAddressDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	a := address.NewAPI(c)
 
 	err := a.Delete(ctx, d.Id())

--- a/anxcloud/resource_ip_address_test.go
+++ b/anxcloud/resource_ip_address_test.go
@@ -3,12 +3,12 @@ package anxcloud
 import (
 	"context"
 	"fmt"
-	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 	"testing"
+
+	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/address"
 )
 
@@ -85,7 +85,7 @@ func testAccAnxCloudIPAddress(resourceName, prefixID, ipAddress, role string) st
 }
 
 func testAccAnxCloudIPAddressDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(client.Client)
+	c := testAccProvider.Meta().(providerContext).legacyClient
 	a := address.NewAPI(c)
 	ctx := context.Background()
 	for _, rs := range s.RootModule().Resources {

--- a/anxcloud/resource_network_prefix.go
+++ b/anxcloud/resource_network_prefix.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/prefix"
 )
 
@@ -38,7 +37,7 @@ func resourceNetworkPrefix() *schema.Resource {
 }
 
 func resourceNetworkPrefixCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	p := prefix.NewAPI(c)
 	locationID := d.Get("location_id").(string)
 
@@ -79,7 +78,7 @@ func resourceNetworkPrefixCreate(ctx context.Context, d *schema.ResourceData, m 
 func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags []diag.Diagnostic
 
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	p := prefix.NewAPI(c)
 
 	info, err := p.Get(ctx, d.Id())
@@ -143,7 +142,7 @@ func resourceNetworkPrefixRead(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceNetworkPrefixUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	p := prefix.NewAPI(c)
 
 	if !d.HasChange("description_customer") {
@@ -161,7 +160,7 @@ func resourceNetworkPrefixUpdate(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func resourceNetworkPrefixDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	p := prefix.NewAPI(c)
 
 	if err := p.Delete(ctx, d.Id()); err != nil {

--- a/anxcloud/resource_network_prefix_test.go
+++ b/anxcloud/resource_network_prefix_test.go
@@ -3,12 +3,12 @@ package anxcloud
 import (
 	"context"
 	"fmt"
-	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 	"testing"
+
+	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/prefix"
 )
 
@@ -68,7 +68,7 @@ func TestAccAnxCloudNetworkPrefix(t *testing.T) {
 }
 
 func testAccCheckAnxCloudNetworkPrefixDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(client.Client)
+	c := testAccProvider.Meta().(providerContext).legacyClient
 	p := prefix.NewAPI(c)
 	ctx := context.Background()
 	for _, rs := range s.RootModule().Resources {
@@ -112,7 +112,7 @@ func testAccAnxCloudNetworkPrefix(resourceName, locationID, customerDescription 
 func testAccAnxCloudNetworkPrefixExists(n string, expectedCustomerDescription string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		c := testAccProvider.Meta().(client.Client)
+		c := testAccProvider.Meta().(providerContext).legacyClient
 		p := prefix.NewAPI(c)
 		ctx := context.Background()
 

--- a/anxcloud/resource_tag.go
+++ b/anxcloud/resource_tag.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/core/resource"
 	"go.anx.io/go-anxcloud/pkg/core/tags"
 )
@@ -90,16 +89,16 @@ func resourceTagDelete(ctx context.Context, d *schema.ResourceData, m interface{
 	return nil
 }
 
-func attachTag(ctx context.Context, c client.Client, resourceID, tagName string) error {
-	r := resource.NewAPI(c)
+func attachTag(ctx context.Context, m providerContext, resourceID, tagName string) error {
+	r := resource.NewAPI(m.legacyClient)
 	if _, err := r.AttachTag(ctx, resourceID, tagName); err != nil {
 		return err
 	}
 	return nil
 }
 
-func detachTag(ctx context.Context, c client.Client, resourceID, tagName string) error {
-	r := resource.NewAPI(c)
+func detachTag(ctx context.Context, m providerContext, resourceID, tagName string) error {
+	r := resource.NewAPI(m.legacyClient)
 	if err := r.DetachTag(ctx, resourceID, tagName); err != nil {
 		return err
 	}

--- a/anxcloud/resource_tag.go
+++ b/anxcloud/resource_tag.go
@@ -32,7 +32,7 @@ func resourceTag() *schema.Resource {
 }
 
 func resourceTagCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	t := tags.NewAPI(c)
 
 	def := tags.Create{
@@ -53,7 +53,7 @@ func resourceTagCreate(ctx context.Context, d *schema.ResourceData, m interface{
 func resourceTagRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags []diag.Diagnostic
 
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	t := tags.NewAPI(c)
 
 	info, err := t.Get(ctx, d.Id())
@@ -80,7 +80,7 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, m interface{})
 }
 
 func resourceTagDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	t := tags.NewAPI(c)
 
 	if err := t.Delete(ctx, d.Id(), d.Get("service_id").(string)); err != nil {

--- a/anxcloud/resource_tag_test.go
+++ b/anxcloud/resource_tag_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/core/tags"
 )
 
@@ -40,7 +39,7 @@ func TestAccAnxCloudTag(t *testing.T) {
 }
 
 func testAccCheckAnxCloudTagDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(client.Client)
+	c := testAccProvider.Meta().(providerContext).legacyClient
 	t := tags.NewAPI(c)
 	ctx := context.Background()
 	for _, rs := range s.RootModule().Resources {
@@ -76,7 +75,7 @@ func testAccAnxCloudTag(resourceName, serviceID string) string {
 func testAccAnxCloudTagExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		c := testAccProvider.Meta().(client.Client)
+		c := testAccProvider.Meta().(providerContext).legacyClient
 		t := tags.NewAPI(c)
 		ctx := context.Background()
 

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -144,7 +144,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		disks    []Disk
 	)
 
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	vsphereAPI := vsphere.NewAPI(c)
 	addressAPI := address.NewAPI(c)
 	locationID := d.Get("location_id").(string)
@@ -280,7 +280,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	vsphereAPI := vsphere.NewAPI(c)
 	nicAPI := nictype.NewAPI(c)
 
@@ -425,7 +425,7 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	vsphereAPI := vsphere.NewAPI(c)
 	ch := vm.Change{
 		Reboot:          d.Get("force_restart_if_needed").(bool),
@@ -557,7 +557,7 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func resourceVirtualServerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	vsphereAPI := vsphere.NewAPI(c)
 	progressAPI := progress.NewAPI(c)
 

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/ipam/address"
 	"go.anx.io/go-anxcloud/pkg/vsphere"
 	"go.anx.io/go-anxcloud/pkg/vsphere/provisioning/nictype"
@@ -144,9 +143,9 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		disks    []Disk
 	)
 
-	c := m.(providerContext).legacyClient
-	vsphereAPI := vsphere.NewAPI(c)
-	addressAPI := address.NewAPI(c)
+	provContext := m.(providerContext)
+	vsphereAPI := vsphere.NewAPI(provContext.legacyClient)
+	addressAPI := address.NewAPI(provContext.legacyClient)
 	locationID := d.Get("location_id").(string)
 
 	networks = expandVirtualServerNetworks(d.Get("network").([]interface{}))
@@ -257,7 +256,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	tags := expandTags(d.Get("tags").([]interface{}))
 	for _, t := range tags {
-		if err := attachTag(ctx, c, d.Id(), t); err != nil {
+		if err := attachTag(ctx, provContext, d.Id(), t); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -268,7 +267,7 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		}
 
 		initialDisks := expandVirtualServerDisks(d.Get("disk").([]interface{}))
-		if update := updateVirtualServerDisk(ctx, c, d.Id(), disks, initialDisks); update != nil {
+		if update := updateVirtualServerDisk(ctx, provContext, d.Id(), disks, initialDisks); update != nil {
 			return update
 		}
 	}
@@ -425,8 +424,8 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(providerContext).legacyClient
-	vsphereAPI := vsphere.NewAPI(c)
+	provContext := m.(providerContext)
+	vsphereAPI := vsphere.NewAPI(provContext.legacyClient)
 	ch := vm.Change{
 		Reboot:          d.Get("force_restart_if_needed").(bool),
 		EnableDangerous: d.Get("critical_operation_confirmed").(bool),
@@ -500,13 +499,13 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 		cTags := getTagsDifferences(newTags, oldTags)
 
 		for _, t := range dTags {
-			if err := detachTag(ctx, c, d.Id(), t); err != nil {
+			if err := detachTag(ctx, provContext, d.Id(), t); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
 		for _, t := range cTags {
-			if err := attachTag(ctx, c, d.Id(), t); err != nil {
+			if err := attachTag(ctx, provContext, d.Id(), t); err != nil {
 				return diag.FromErr(err)
 			}
 		}
@@ -614,7 +613,7 @@ func getTagsDifferences(tagsA, tagsB []string) []string {
 	return out
 }
 
-func updateVirtualServerDisk(ctx context.Context, c client.Client, id string, expected []Disk, current []Disk) diag.Diagnostics {
+func updateVirtualServerDisk(ctx context.Context, m providerContext, id string, expected []Disk, current []Disk) diag.Diagnostics {
 	changeDisks := make([]vm.Disk, 0, len(current))
 	addDisks := make([]vm.Disk, 0, len(expected))
 	for diskIndex := range current {
@@ -644,7 +643,7 @@ func updateVirtualServerDisk(ctx context.Context, c client.Client, id string, ex
 		ChangeDisks: changeDisks,
 	}
 
-	v := vsphere.NewAPI(c)
+	v := vsphere.NewAPI(m.legacyClient)
 	var response vm.ProvisioningResponse
 	provisioning := v.Provisioning()
 	var err error

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -300,7 +300,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 }
 
 func testAccCheckAnxCloudVirtualServerDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(client.Client)
+	c := testAccProvider.Meta().(providerContext).legacyClient
 	v := vsphere.NewAPI(c)
 	ctx := context.Background()
 
@@ -389,7 +389,7 @@ func testAccConfigAnxCloudVirtualServerMultiDiskSupport(resourceName string, def
 func testAccCheckAnxCloudVirtualServerExists(n string, def *vm.Definition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		c := testAccProvider.Meta().(client.Client)
+		c := testAccProvider.Meta().(providerContext).legacyClient
 		v := vsphere.NewAPI(c)
 		ctx := context.Background()
 
@@ -441,7 +441,7 @@ func testAccCheckAnxCloudVirtualServerExists(n string, def *vm.Definition) resou
 func testAccCheckAnxCloudVirtualServerDisks(n string, expectedDisks []vm.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		c := testAccProvider.Meta().(client.Client)
+		c := testAccProvider.Meta().(providerContext).legacyClient
 		v := vsphere.NewAPI(c)
 		ctx := context.Background()
 

--- a/anxcloud/resource_vlan.go
+++ b/anxcloud/resource_vlan.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vlan"
 )
 
@@ -37,7 +36,7 @@ func resourceVLAN() *schema.Resource {
 }
 
 func resourceVLANCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	v := vlan.NewAPI(c)
 	locationID := d.Get("location_id").(string)
 
@@ -71,7 +70,7 @@ func resourceVLANCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceVLANRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags []diag.Diagnostic
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	v := vlan.NewAPI(c)
 
 	vlan, err := v.Get(ctx, d.Id())
@@ -115,7 +114,7 @@ func resourceVLANRead(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func resourceVLANUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	vlanAPI := vlan.NewAPI(c)
 
 	if !d.HasChange("description_customer") && !d.HasChange("vm_provisioning") {
@@ -154,7 +153,7 @@ func resourceVLANUpdate(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceVLANDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(client.Client)
+	c := m.(providerContext).legacyClient
 	v := vlan.NewAPI(c)
 
 	err := v.Delete(ctx, d.Id())

--- a/anxcloud/resource_vlan_test.go
+++ b/anxcloud/resource_vlan_test.go
@@ -3,12 +3,12 @@ package anxcloud
 import (
 	"context"
 	"fmt"
-	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 	"testing"
+
+	"github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"go.anx.io/go-anxcloud/pkg/vlan"
 )
 
@@ -61,7 +61,7 @@ func TestAccAnxCloudVLAN(t *testing.T) {
 }
 
 func testAccCheckAnxCloudVLANDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(client.Client)
+	c := testAccProvider.Meta().(providerContext).legacyClient
 	v := vlan.NewAPI(c)
 	ctx := context.Background()
 	for _, rs := range s.RootModule().Resources {
@@ -101,7 +101,7 @@ func testAccCheckAnxCloudVLAN(resourceName, locationID, customerDescription stri
 func testAccCheckAnxCloudVLANExists(n string, expectedCustomerDescription string, expectedVMProvisioning bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		c := testAccProvider.Meta().(client.Client)
+		c := testAccProvider.Meta().(providerContext).legacyClient
 		v := vlan.NewAPI(c)
 		ctx := context.Background()
 


### PR DESCRIPTION
Refactor existing code to get the legacy api client from provider context struct instead of the context directly

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use the following format:
 * <resource-type>[/<resource-name>] - <short description of what has been done>

where resource-type can be something like 'resource', 'data', 'all resources', '**New Resource**', '**New Datasource**' 

e.g.

* resource/anxcloud_ip_address - fix IP address cleanup
-->

```release-note
none (internal)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
