### PR TITLE
Implements anxcloud_core_location data-source

### DIFF
--- a/anxcloud/data_source_core_location.go
+++ b/anxcloud/data_source_core_location.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceCoreLocation() *schema.Resource {
 	return &schema.Resource{
-		Description: "Retrieves Location identified by it's `code`.",
+		Description: "Retrieves Location identified by it's `code` as selectable in the Engine.",
 		ReadContext: dataSourceCoreLocationRead,
 		Schema:      schemaLocation(),
 	}

--- a/anxcloud/data_source_core_location.go
+++ b/anxcloud/data_source_core_location.go
@@ -1,0 +1,78 @@
+package anxcloud
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+)
+
+func dataSourceCoreLocation() *schema.Resource {
+	return &schema.Resource{
+		Description: "Retrieves Location identified by it's `code`.",
+		ReadContext: dataSourceCoreLocationRead,
+		Schema:      schemaLocation(),
+	}
+}
+
+func dataSourceCoreLocationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	a := m.(providerContext).api
+
+	code, exists := d.GetOk("code")
+	if !exists {
+		return diag.Errorf("location data-source requires code argument")
+	}
+
+	searchLocation := &corev1.Location{Code: code.(string)}
+	channel := make(types.ObjectChannel)
+	if err := a.List(ctx, searchLocation, api.ObjectChannel(&channel)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	found := false
+	location := &corev1.Location{}
+	for res := range channel {
+		if err := res(location); err != nil {
+			return diag.FromErr(err)
+		}
+		if location.Code == searchLocation.Code {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return diag.Errorf("location with specified code not found")
+	}
+
+	var err error
+	var diags []diag.Diagnostic
+
+	d.SetId(location.Identifier)
+	if err = d.Set("identifier", location.Identifier); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("name", location.Name); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("code", location.Code); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("country", location.CountryCode); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("city_code", location.CityCode); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("lat", location.Latitude); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err = d.Set("lon", location.Longitude); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
+	return diags
+}

--- a/anxcloud/data_source_core_location.go
+++ b/anxcloud/data_source_core_location.go
@@ -26,9 +26,11 @@ func dataSourceCoreLocationRead(ctx context.Context, d *schema.ResourceData, m i
 		return diag.Errorf("location data-source requires code argument")
 	}
 
+	listCTX, cancel := context.WithCancel(ctx)
+	defer cancel()
 	searchLocation := &corev1.Location{Code: code.(string)}
 	channel := make(types.ObjectChannel)
-	if err := a.List(ctx, searchLocation, api.ObjectChannel(&channel)); err != nil {
+	if err := a.List(listCTX, searchLocation, api.ObjectChannel(&channel)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/anxcloud/data_source_core_location.go
+++ b/anxcloud/data_source_core_location.go
@@ -26,11 +26,11 @@ func dataSourceCoreLocationRead(ctx context.Context, d *schema.ResourceData, m i
 		return diag.Errorf("location data-source requires code argument")
 	}
 
-	listCTX, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	searchLocation := &corev1.Location{Code: code.(string)}
 	channel := make(types.ObjectChannel)
-	if err := a.List(listCTX, searchLocation, api.ObjectChannel(&channel)); err != nil {
+	if err := a.List(ctx, searchLocation, api.ObjectChannel(&channel)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/anxcloud/data_source_core_location_test.go
+++ b/anxcloud/data_source_core_location_test.go
@@ -1,0 +1,40 @@
+package anxcloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAnxCloudCoreLocationDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnxCloudCoreLocationDataSource("anx04", "ANX04"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.anxcloud_core_location.anx04", "identifier", "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"),
+				),
+			},
+			{
+				Config:      testAccAnxCloudCoreLocationDataSource("test", "invalid-code"),
+				ExpectError: regexp.MustCompile("location with specified code not found"),
+			},
+			{
+				Config:      `data "anxcloud_core_location" "test" {}`,
+				ExpectError: regexp.MustCompile("location data-source requires code argument"),
+			},
+		},
+	})
+}
+
+func testAccAnxCloudCoreLocationDataSource(dataSourceName, code string) string {
+	return fmt.Sprintf(`
+	data "anxcloud_core_location" "%s" {
+		code = "%s"
+	}
+	`, dataSourceName, code)
+}

--- a/anxcloud/data_source_core_locations.go
+++ b/anxcloud/data_source_core_locations.go
@@ -13,7 +13,7 @@ import (
 func dataSourceCoreLocations() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceCoreLocationsRead,
-		Schema:      schemaDataSourceLocation(),
+		Schema:      schemaDataSourceLocations(),
 	}
 }
 

--- a/anxcloud/provider.go
+++ b/anxcloud/provider.go
@@ -43,6 +43,7 @@ func Provider() *schema.Provider {
 			"anxcloud_template":              dataSourceTemplate(),
 			"anxcloud_ip_addresses":          dataSourceIPAddresses(),
 			"anxcloud_nic_types":             dataSourceNICTypes(),
+			"anxcloud_core_location":         dataSourceCoreLocation(),
 			"anxcloud_core_locations":        dataSourceCoreLocations(),
 			"anxcloud_vlans":                 dataSourceVLANs(),
 			"anxcloud_tags":                  dataSourceTags(),

--- a/anxcloud/schema_locations.go
+++ b/anxcloud/schema_locations.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func schemaDataSourceLocation() map[string]*schema.Schema {
+func schemaDataSourceLocations() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"page": {
 			Type:        schema.TypeInt,
@@ -27,49 +27,53 @@ func schemaDataSourceLocation() map[string]*schema.Schema {
 	}
 }
 
+func schemaLocation() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"identifier": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Identifier of the location.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Name of the location.",
+		},
+		"code": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Location code.",
+		},
+		"country": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Location country.",
+		},
+		"city_code": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Location city code.",
+		},
+		"lat": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Location latitude.",
+		},
+		"lon": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Location longitude.",
+		},
+	}
+}
+
 func schemaLocations() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "Anexia Cloud Locations.",
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"identifier": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Identifier of the location.",
-				},
-				"name": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Name of the location.",
-				},
-				"code": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Location code.",
-				},
-				"country": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Location country.",
-				},
-				"city_code": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Location city code.",
-				},
-				"lat": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Location latitude.",
-				},
-				"lon": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Location longitude.",
-				},
-			},
+			Schema: schemaLocation(),
 		},
 	}
 }

--- a/anxcloud/struct_dns_records_test.go
+++ b/anxcloud/struct_dns_records_test.go
@@ -1,15 +1,16 @@
 package anxcloud
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	uuid "github.com/satori/go.uuid"
 	"go.anx.io/go-anxcloud/pkg/clouddns/zone"
-	"testing"
 )
 
 func TestFlattenDnsRecords(t *testing.T) {
-	id := uuid.NewV4()
-	id2 := uuid.NewV4()
+	id, _ := uuid.NewV4()
+	id2, _ := uuid.NewV4()
 	ttl := 100
 	cases := []struct {
 		Input          []zone.Record

--- a/go.mod
+++ b/go.mod
@@ -34,10 +34,10 @@ require (
 	github.com/onsi/ginkgo/v2 v2.0.0
 	github.com/onsi/gomega v1.17.0
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.10.0 // indirect
-	go.anx.io/go-anxcloud v0.4.0
+	go.anx.io/go-anxcloud v0.4.2
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -445,8 +445,8 @@ github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUA
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
-go.anx.io/go-anxcloud v0.4.0 h1:Pql0Z2BkjfG0rXefsmP4oEoV+whd80PSmuR0Wh55/pk=
-go.anx.io/go-anxcloud v0.4.0/go.mod h1:U/rB3kGkiXGlt7S4e9I9PeSMVt40MM0IdLAvAm/Gngc=
+go.anx.io/go-anxcloud v0.4.2 h1:+/snGC50r1Csa1GvG4lZFZIuIdbVEXoxAE2uQ/cKuJs=
+go.anx.io/go-anxcloud v0.4.2/go.mod h1:6ODWdaHvPBB0heOL9hqymgs1YSNwcUJ2LyammAYJFsI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Implements `anxcloud_core_location` data-source. Allows Location to be fetched by it's human-readable `code`-identifier.


### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAnxCloudCoreLocationDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAnxCloudCoreLocationDataSource -timeout 120m
?       github.com/anexia-it/terraform-provider-anxcloud        [no test files]
2022/05/02 15:06:15 Setting up new test environment
2022/05/02 15:06:15 Random Test Name: dark-snowflake
=== RUN   TestAccAnxCloudCoreLocationDataSource
--- PASS: TestAccAnxCloudCoreLocationDataSource (12.49s)
PASS
ok      github.com/anexia-it/terraform-provider-anxcloud/anxcloud       45.888s
?       github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/environment [no test files]
?       github.com/anexia-it/terraform-provider-anxcloud/anxcloud/testutils/recorder    [no test files]
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use the following format:
 * <resource-type>[/<resource-name>] - <short description of what has been done>

where resource-type can be something like 'resource', 'data', 'all resources', '**New Resource**', '**New Datasource**' 

e.g.

* resource/anxcloud_ip_address - fix IP address cleanup
-->

```release-note
* core/v1/Location - implement singular anxcloud_core_location data-source (matched with `code` argument)
* upgrade go-anxcloud dependency to 0.4.2
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
