### PR TITLE
Fix DNS function naming

### DIFF
--- a/anxcloud/data_source_dns_records.go
+++ b/anxcloud/data_source_dns_records.go
@@ -27,7 +27,7 @@ func dataSourceDNSRecordsRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("records", flattenDnsRecords(records)); err != nil {
+	if err := d.Set("records", flattenDNSRecords(records)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/anxcloud/data_source_dns_records_test.go
+++ b/anxcloud/data_source_dns_records_test.go
@@ -3,12 +3,13 @@ package anxcloud
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
-func TestAccAnxCloudDnsRecordsDataSource(t *testing.T) {
+func TestAccAnxCloudDNSRecordsDataSource(t *testing.T) {
 	resourceName := "acc_test"
 	resourcePath := "data.anxcloud_dns_records." + resourceName
 
@@ -19,17 +20,17 @@ func TestAccAnxCloudDnsRecordsDataSource(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAnxCloudDnsRecordsDataSource(resourceName, zoneName),
+				Config: testAccAnxCloudDNSRecordsDataSource(resourceName, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourcePath, "zone_name", zoneName),
-					testAccAnxCloudDnsRecordsDataSourceExists(resourcePath),
+					testAccAnxCloudDNSRecordsDataSourceExists(resourcePath),
 				),
 			},
 		},
 	})
 }
 
-func testAccAnxCloudDnsRecordsDataSource(resourceName, zoneName string) string {
+func testAccAnxCloudDNSRecordsDataSource(resourceName, zoneName string) string {
 	return fmt.Sprintf(`
 	data "anxcloud_dns_records" "%s" { 
 		zone_name = "%s" 
@@ -37,7 +38,7 @@ func testAccAnxCloudDnsRecordsDataSource(resourceName, zoneName string) string {
 `, resourceName, zoneName)
 }
 
-func testAccAnxCloudDnsRecordsDataSourceExists(n string) resource.TestCheckFunc {
+func testAccAnxCloudDNSRecordsDataSourceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/anxcloud/data_source_dns_zones.go
+++ b/anxcloud/data_source_dns_zones.go
@@ -39,7 +39,7 @@ func dataSourceDNSZonesRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-	if err = d.Set("zones", flattenDnsZones(zones)); err != nil {
+	if err = d.Set("zones", flattenDNSZones(zones)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/anxcloud/data_source_dns_zones_test.go
+++ b/anxcloud/data_source_dns_zones_test.go
@@ -3,12 +3,13 @@ package anxcloud
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
-func TestAccAnxCloudDnsZonesDataSource(t *testing.T) {
+func TestAccAnxCloudDNSZonesDataSource(t *testing.T) {
 	resourceName := "acc_test"
 	resourcePath := "data.anxcloud_dns_zones." + resourceName
 
@@ -17,22 +18,22 @@ func TestAccAnxCloudDnsZonesDataSource(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAnxCloudDnsZonesDataSource(resourceName),
+				Config: testAccAnxCloudDNSZonesDataSource(resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAnxCloudDnsZonesDataSourceExists(resourcePath),
+					testAccAnxCloudDNSZonesDataSourceExists(resourcePath),
 				),
 			},
 		},
 	})
 }
 
-func testAccAnxCloudDnsZonesDataSource(resourceName string) string {
+func testAccAnxCloudDNSZonesDataSource(resourceName string) string {
 	return fmt.Sprintf(`
 	data "anxcloud_dns_zones" "%s" {}
 `, resourceName)
 }
 
-func testAccAnxCloudDnsZonesDataSourceExists(n string) resource.TestCheckFunc {
+func testAccAnxCloudDNSZonesDataSourceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/anxcloud/struct_dns_records.go
+++ b/anxcloud/struct_dns_records.go
@@ -2,7 +2,7 @@ package anxcloud
 
 import "go.anx.io/go-anxcloud/pkg/clouddns/zone"
 
-func flattenDnsRecords(records []zone.Record) []interface{} {
+func flattenDNSRecords(records []zone.Record) []interface{} {
 	zoneRecords := make([]interface{}, 0, len(records))
 	if len(records) < 1 {
 		return zoneRecords

--- a/anxcloud/struct_dns_records_test.go
+++ b/anxcloud/struct_dns_records_test.go
@@ -63,7 +63,7 @@ func TestFlattenDnsRecords(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output := flattenDnsRecords(tc.Input)
+		output := flattenDNSRecords(tc.Input)
 		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
 			t.Fatalf("Unexpected output from flattener: missmatch (-want +got):\n%s", diff)
 		}

--- a/anxcloud/struct_dns_zones.go
+++ b/anxcloud/struct_dns_zones.go
@@ -4,7 +4,7 @@ import (
 	clouddnsv1 "go.anx.io/go-anxcloud/pkg/apis/clouddns/v1"
 )
 
-func flattenDnsZones(dnsZones []clouddnsv1.Zone) []interface{} {
+func flattenDNSZones(dnsZones []clouddnsv1.Zone) []interface{} {
 	zones := make([]interface{}, 0, len(dnsZones))
 
 	for _, zone := range dnsZones {

--- a/anxcloud/struct_dns_zones_test.go
+++ b/anxcloud/struct_dns_zones_test.go
@@ -109,7 +109,7 @@ func TestFlattenDnsZones(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output := flattenDnsZones(tc.Input)
+		output := flattenDNSZones(tc.Input)
 		if diff := cmp.Diff(tc.ExpectedOutput, output); diff != "" {
 			t.Fatalf("Unexpected output from flattener: missmatch (-want +got):\n%s", diff)
 		}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Fix DNS function naming to make linter happy 🙂
### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use the following format:
 * <resource-type>[/<resource-name>] - <short description of what has been done>

where resource-type can be something like 'resource', 'data', 'all resources', '**New Resource**', '**New Datasource**' 

e.g.

* resource/anxcloud_ip_address - fix IP address cleanup
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
