### PR TITLE
Added support for named vServer templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 
 ### Added
 * data-source/anxcloud_ip_address: allows users to retreive IP objects by id or address (#91, @marioreggiori)
+* resource/anxcloud_virtual_server: support named vServer templates (#95, @marioreggiori)
 
 ### Changed
 * resource/anxcloud_virtual_server: bootstrap script example added (#89, @marioreggiori)

--- a/anxcloud/helper_test.go
+++ b/anxcloud/helper_test.go
@@ -1,0 +1,15 @@
+package anxcloud
+
+import (
+	"testing"
+
+	"go.anx.io/go-anxcloud/pkg/client"
+)
+
+func integrationTestClientFromEnv(t *testing.T) client.Client {
+	c, err := client.New(client.AuthFromEnv(false))
+	if err != nil {
+		t.Errorf("failed to initialize integration test client from env: %s", err)
+	}
+	return c
+}

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -18,17 +18,35 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Location identifier.",
 		},
-		"template_id": {
+		"template": {
+			Type:         schema.TypeString,
+			ForceNew:     true,
+			Optional:     true,
+			ExactlyOneOf: []string{"template_id", "template"},
+			Description: "Named template. Can be used instead of the template_id to select a template. " +
+				"Example: (`Debian 11`, `Windows 2022`).",
+		},
+		"template_build": {
 			Type:        schema.TypeString,
-			Required:    true,
 			ForceNew:    true,
-			Description: "Template identifier.",
+			Optional:    true,
+			Default:     "latest",
+			Description: "Template build identifier optionally used with `template`. Will default to latest build. Example: `b42`",
+		},
+		"template_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ExactlyOneOf: []string{"template_id", "template"},
+			Description:  "Template identifier.",
 		},
 		"template_type": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: "OS template type.",
+			Type:         schema.TypeString,
+			ForceNew:     true,
+			Description:  "OS template type.",
+			Optional:     true,
+			Default:      "templates",
+			RequiredWith: []string{"template_id"},
 		},
 		"cpus": {
 			Type:        schema.TypeInt,

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,59 +39,96 @@ data "anxcloud_core_location" "anx04" {
   code = "ANX04"
 }
 
-data "anxcloud_template" "anx04" {
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_type = "templates"
-}
-
-locals {
-  debian_11_templates = values({
-    for i, template in data.anxcloud_template.anx04.templates : tostring(i) => template
-    if substr(template.name, 0, 9) == "Debian 11"
-  })
-}
-
 resource "anxcloud_vlan" "example" {
-  description_customer = "example-terraform"
   location_id          = data.anxcloud_core_location.anx04.id
   vm_provisioning      = true
+  description_customer = "example-terraform"
 }
 
-resource "anxcloud_network_prefix" "example" {
-  vlan_id     = anxcloud_vlan.example.id
+resource "anxcloud_network_prefix" "v4" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 4
+  netmask              = 30
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_network_prefix" "v6" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 6
+  netmask              = 126
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_ip_address" "v4" {
+  address           = cidrhost(anxcloud_network_prefix.v4.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v4.id
+}
+
+resource "anxcloud_ip_address" "v6" {
+  address           = cidrhost(anxcloud_network_prefix.v6.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v6.id
+}
+
+resource "anxcloud_virtual_server" "webserver" {
+  hostname    = "example-terraform"
   location_id = data.anxcloud_core_location.anx04.id
-  ip_version  = 4
-  type        = 0
-  netmask     = 29
-}
-
-resource "anxcloud_virtual_server" "example" {
-  hostname      = "example-terraform"
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_id   = local.debian_11_templates[0].id
-  template_type = "templates"
+  template    = "Debian 11"
 
   cpus   = 4
   memory = 4096
 
   ssh_key = file("~/.ssh/id_rsa.pub")
 
+  script = <<-EOT
+    #!/bin/bash
+
+    # install nginx server
+    apt update && apt install -y nginx
+    EOT
+
+  # Set network interface
   network {
     vlan_id  = anxcloud_vlan.example.id
+    ips      = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
     nic_type = "vmxnet3"
   }
 
-  # Disk 1
   disk {
     disk_gb   = 100
     disk_type = "STD1"
   }
 
   dns = ["8.8.8.8"]
+}
 
-  depends_on = [
-    anxcloud_network_prefix.example
-  ]
+resource "anxcloud_dns_zone" "example" {
+  name         = "example.com"
+  admin_email  = "admin@example.com"
+  dns_sec_mode = "managed"
+  is_master    = true
+  refresh      = 14400
+  retry        = 3600
+  expire       = 604800
+  ttl          = 3600
+}
+
+
+resource "anxcloud_dns_record" "webserver_v4" {
+  name      = "www"
+  zone_name = "example.com"
+  type      = "A"
+  rdata     = anxcloud_ip_address.v4.address
+  ttl       = 3600
+}
+
+resource "anxcloud_dns_record" "webserver_v6" {
+  name      = "www"
+  zone_name = "example.com"
+  type      = "AAAA"
+  rdata     = anxcloud_ip_address.v6.address
+  ttl       = 3600
 }
 ```
 

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -21,29 +21,42 @@ data "anxcloud_core_location" "anx04" {
   code = "ANX04"
 }
 
-data "anxcloud_template" "anx04" {
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_type = "templates"
-}
-
-locals {
-  debian_11_templates = values({
-    for i, template in data.anxcloud_template.anx04.templates : tostring(i) => template
-    if substr(template.name, 0, 9) == "Debian 11"
-  })
-}
-
 resource "anxcloud_vlan" "example" {
-  count           = 2
-  location_id     = data.anxcloud_core_location.anx04.id
-  vm_provisioning = true
+  location_id          = data.anxcloud_core_location.anx04.id
+  vm_provisioning      = true
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_network_prefix" "v4" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 4
+  netmask              = 30
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_network_prefix" "v6" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 6
+  netmask              = 126
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_ip_address" "v4" {
+  address           = cidrhost(anxcloud_network_prefix.v4.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v4.id
+}
+
+resource "anxcloud_ip_address" "v6" {
+  address           = cidrhost(anxcloud_network_prefix.v6.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v6.id
 }
 
 resource "anxcloud_virtual_server" "example" {
-  hostname      = "example-terraform"
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_id   = local.debian_11_templates[0].id
-  template_type = "templates"
+  hostname    = "example-terraform"
+  location_id = data.anxcloud_core_location.anx04.id
+  template    = "Debian 11"
 
   cpus   = 4
   memory = 4096
@@ -59,16 +72,10 @@ resource "anxcloud_virtual_server" "example" {
     apt update && apt install -y nginx
     EOT
 
-  # set two network interfaces
-  # NIC 1
+  # Set network interface
   network {
-    vlan_id  = anxcloud_vlan.example[0].id
-    nic_type = "vmxnet3"
-  }
-
-  # NIC 2
-  network {
-    vlan_id  = anxcloud_vlan.example[1].id
+    vlan_id  = anxcloud_vlan.example.id
+    ips      = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
     nic_type = "vmxnet3"
   }
 
@@ -98,8 +105,6 @@ resource "anxcloud_virtual_server" "example" {
 - `hostname` (String) Virtual server hostname.
 - `location_id` (String) Location identifier.
 - `memory` (Number) Memory in MB.
-- `template_id` (String) Template identifier.
-- `template_type` (String) OS template type.
 
 ### Optional
 
@@ -116,6 +121,10 @@ resource "anxcloud_virtual_server" "example" {
 - `sockets` (Number) Amount of CPU sockets Number of cores have to be a multiple of sockets, as they will be spread evenly across all sockets. Defaults to number of cores, i.e. one socket per CPU core.
 - `ssh_key` (String) Public key (instead of password, only for Linux systems). Recommended over providing a plaintext password.
 - `tags` (List of String) List of tags attached to the Virtual Server.
+- `template` (String) Named template. Can be used instead of the template_id to select a template. Example: (`Debian 11`, `Windows 2022`).
+- `template_build` (String) Template build identifier optionally used with `template`. Will default to latest build. Example: `b42`
+- `template_id` (String) Template identifier.
+- `template_type` (String) OS template type.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -20,57 +20,94 @@ data "anxcloud_core_location" "anx04" {
   code = "ANX04"
 }
 
-data "anxcloud_template" "anx04" {
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_type = "templates"
-}
-
-locals {
-  debian_11_templates = values({
-    for i, template in data.anxcloud_template.anx04.templates : tostring(i) => template
-    if substr(template.name, 0, 9) == "Debian 11"
-  })
-}
-
 resource "anxcloud_vlan" "example" {
-  description_customer = "example-terraform"
   location_id          = data.anxcloud_core_location.anx04.id
   vm_provisioning      = true
+  description_customer = "example-terraform"
 }
 
-resource "anxcloud_network_prefix" "example" {
-  vlan_id     = anxcloud_vlan.example.id
+resource "anxcloud_network_prefix" "v4" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 4
+  netmask              = 30
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_network_prefix" "v6" {
+  vlan_id              = anxcloud_vlan.example.id
+  location_id          = data.anxcloud_core_location.anx04.id
+  ip_version           = 6
+  netmask              = 126
+  description_customer = "example-terraform"
+}
+
+resource "anxcloud_ip_address" "v4" {
+  address           = cidrhost(anxcloud_network_prefix.v4.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v4.id
+}
+
+resource "anxcloud_ip_address" "v6" {
+  address           = cidrhost(anxcloud_network_prefix.v6.cidr, 2)
+  network_prefix_id = anxcloud_network_prefix.v6.id
+}
+
+resource "anxcloud_virtual_server" "webserver" {
+  hostname    = "example-terraform"
   location_id = data.anxcloud_core_location.anx04.id
-  ip_version  = 4
-  type        = 0
-  netmask     = 29
-}
-
-resource "anxcloud_virtual_server" "example" {
-  hostname      = "example-terraform"
-  location_id   = data.anxcloud_core_location.anx04.id
-  template_id   = local.debian_11_templates[0].id
-  template_type = "templates"
+  template    = "Debian 11"
 
   cpus   = 4
   memory = 4096
 
   ssh_key = file("~/.ssh/id_rsa.pub")
 
+  script = <<-EOT
+    #!/bin/bash
+
+    # install nginx server
+    apt update && apt install -y nginx
+    EOT
+
+  # Set network interface
   network {
     vlan_id  = anxcloud_vlan.example.id
+    ips      = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
     nic_type = "vmxnet3"
   }
 
-  # Disk 1
   disk {
     disk_gb   = 100
     disk_type = "STD1"
   }
 
   dns = ["8.8.8.8"]
+}
 
-  depends_on = [
-    anxcloud_network_prefix.example
-  ]
+resource "anxcloud_dns_zone" "example" {
+  name         = "example.com"
+  admin_email  = "admin@example.com"
+  dns_sec_mode = "managed"
+  is_master    = true
+  refresh      = 14400
+  retry        = 3600
+  expire       = 604800
+  ttl          = 3600
+}
+
+
+resource "anxcloud_dns_record" "webserver_v4" {
+  name      = "www"
+  zone_name = "example.com"
+  type      = "A"
+  rdata     = anxcloud_ip_address.v4.address
+  ttl       = 3600
+}
+
+resource "anxcloud_dns_record" "webserver_v6" {
+  name      = "www"
+  zone_name = "example.com"
+  type      = "AAAA"
+  rdata     = anxcloud_ip_address.v6.address
+  ttl       = 3600
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Added support for named vServer templates.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/terraform-provider-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use the following format:
 * <resource-type>[/<resource-name>] - <short description of what has been done>

where resource-type can be something like 'resource', 'data', 'all resources', '**New Resource**', '**New Datasource**' 

e.g.

* resource/anxcloud_ip_address - fix IP address cleanup
-->

```release-note

```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
