### PR TITLE
Remove breaking anxcloud_virtual_server defaults

### DIFF
--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -608,6 +608,7 @@ func TestFindNamedTemplate(t *testing.T) {
 		// valid test cases
 		{"844ac596-5f62-4ed2-936e-b99ffe0d4f88", true, "Flatcar Linux Stable", "b72"},
 		{"26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0", true, "Flatcar Linux Stable", "latest"},
+		{"26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0", true, "Flatcar Linux Stable", ""},
 		{"26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0", true, "Flatcar Linux Stable", "b74"},
 		{"b21b8b77-30e3-478a-9b6d-1f61d29e9f9a", true, "Flatcar Linux Stable", "b73"},
 		{"086c5f99-1be6-46ec-8374-cdc23cedd6a4", true, "Windows 2022", "latest"},
@@ -621,7 +622,7 @@ func TestFindNamedTemplate(t *testing.T) {
 		{"", false, "Bar OS 95", "latest"},
 
 		// non-existing build id
-		{"", false, "Windows 2022", ""},
+		{"", false, "Windows 2022", "foo"},
 		{"", false, "Windows 2022", "b00"},
 	}
 

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -30,7 +30,6 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
-			Default:     "latest",
 			Description: "Template build identifier optionally used with `template`. Will default to latest build. Example: `b42`",
 		},
 		"template_id": {
@@ -45,7 +44,6 @@ func schemaVirtualServer() map[string]*schema.Schema {
 			ForceNew:     true,
 			Description:  "OS template type.",
 			Optional:     true,
-			Default:      "templates",
 			RequiredWith: []string{"template_id"},
 		},
 		"cpus": {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
PR #95 unintentionally introduced (unreleased) breaking changes. The `Default` parameter of `template_build` for `anxcloud_virtual_server` will force replacement of resources created with previous provider versions. The added `Default` parameter of `template_type` breaks resources imported with `terraform import`.

This PR removes both Default parameters and makes an empty `template_build` alias for latest.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
