### PR TITLE
Add VM provisioning completion delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Fixed
+* resource/anxcloud_virtual_server: add delay after `AwaitCompletion` to handle pending changes before read (#111, @marioreggiori)
+
 ### Changed
 * resource/anxcloud_virtual_server: increase delete timeout (#112, @marioreggiori)
 

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -268,8 +268,10 @@ func resourceVirtualServerCreate(ctx context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	diags = resourceVirtualServerRead(ctx, d, m)
-	return diags
+	// wait for API to be updated
+	time.Sleep(time.Minute)
+
+	return resourceVirtualServerRead(ctx, d, m)
 }
 
 func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -492,6 +494,9 @@ func resourceVirtualServerUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
+	// wait for API to be updated
+	time.Sleep(time.Minute)
+
 	return resourceVirtualServerRead(ctx, d, m)
 }
 
@@ -576,6 +581,9 @@ func updateVirtualServerDisk(ctx context.Context, m providerContext, id string, 
 	if _, err = provisioning.Progress().AwaitCompletion(ctx, response.Identifier); err != nil {
 		return diag.FromErr(err)
 	}
+
+	// wait for API to be updated
+	time.Sleep(time.Minute)
 
 	vmState := resource.StateChangeConf{
 		Delay:      10 * time.Second,


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Added VM provisioning completion delay to await pending updates. 

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
