### PR TITLE
Increase `anxcloud_virtual_server` resource delete timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Changed
+* resource/anxcloud_virtual_server: increase delete timeout (#112, @marioreggiori)
+
 ## [0.4.0] - 2022-07-07
 
 ### Breaking

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -49,7 +49,7 @@ The virtual_server resource allows you to configure and run virtual machines.
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: withTagsAttribute(schemaVirtualServer()),
 		CustomizeDiff: customdiff.All(


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Increased `anxcloud_virtual_server` resource delete timeout to mitigate longer than usual VM deprovisioning.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
