### PR TITLE
Fix VM provisioning with templates of type `from_scratch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 ### Fixed
 * resource/anxcloud_virtual_server: add delay after `AwaitCompletion` to handle pending changes before read (#111, @marioreggiori)
 * (internal) acceptance tests: make ProviderFactories real factories (#102, @marioreggiori)
+* resource/anxcloud_virtual_server: `from_scratch` template provisioning ability restored (#114, @marioreggiori)
 
 ### Added
 * resource/anxcloud_lbaas_loadbalancer: add a first LBaaS resource (#107, @marioreggiori)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.15.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
@@ -34,6 +33,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Previously implemented check to await updated `network` field at VM info endpoint broke provisioning of VMs with `from_scratch` templates and VMs that have VLANs without any IP configured. #111 makes this check obsolete.


### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
- #51 breaks `from_scratch` template provisioning
- #111 makes breaking check obsolete
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
