### PR TITLE
Fix read-tags error for manually deleted resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Fixed
+* taggable resources: skip reading tags of manually deleted resources on read to prevent error (#117, @marioreggiori)
+
 ### Changed
 * (internal) dependency: upgrade `go-anxcloud` to v0.4.5 (#116, @marioreggiori)
 * data-source/anxcloud_core_location (#116, @marioreggiori)

--- a/anxcloud/common_resource_tagging.go
+++ b/anxcloud/common_resource_tagging.go
@@ -72,7 +72,11 @@ func ensureTagsMiddleware[T schemaContextCreateOrUpdateFunc](wrapped T) T {
 func tagsMiddlewareRead(wrapped schema.ReadContextFunc) schema.ReadContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		diags := wrapped(ctx, d, m)
-		if diags.HasError() {
+		// Resources id can be zero-val after read if remote resource
+		// was deleted manually via engine, but is still present in tf state.
+		// Because reading tags from a non-existing resource fails,
+		// we want to skip tagging logic.
+		if diags.HasError() || d.Id() == "" {
 			return diags
 		}
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Plan for manually deleted engine resources - which are taggable - failed on read because of a missing zero-ID check.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
