### PR TITLE
Refine tag middleware: prevent noop call and fix type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Changed
+* resource tagging:
+  * changing only the tags of a resource no longer causes a noop update call of the resource itself (#121, @marioreggiori)
+  * (internal) change type of `tags` field from list to set and remove obsolete code (#121, @marioreggiori)
+
 ## [0.5.0] - 2022-11-30
 
 ### Added

--- a/docs/resources/ip_address.md
+++ b/docs/resources/ip_address.md
@@ -36,7 +36,7 @@ resource "anxcloud_ip_address" "example" {
 - `description_customer` (String) Additional customer description.
 - `organization` (String) Customer of yours. Reseller only.
 - `role` (String) Role of the IP address
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -51,7 +51,7 @@ resource "anxcloud_kubernetes_node_pool" "example" {
 - `enable_lbaas` (Boolean) If enabled, Service VMs are set up as LBaaS hosts enabling K8s services of type LoadBalancer.
 - `enable_nat_gateways` (Boolean) If enabled, Service VMs are configured as NAT gateways connecting the internal cluster network to the internet.
 - `needs_service_vms` (Boolean) Deploy Service VMs providing load balancers and outbound masquerade.
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `version` (String) Kubernetes version.
 

--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -48,7 +48,7 @@ resource "anxcloud_kubernetes_node_pool" "example" {
 
 ### Optional
 
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/lbaas_loadbalancer.md
+++ b/docs/resources/lbaas_loadbalancer.md
@@ -31,7 +31,7 @@ resource "anxcloud_lbaas_loadbalancer" "example" {
 
 ### Optional
 
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/network_prefix.md
+++ b/docs/resources/network_prefix.md
@@ -45,7 +45,7 @@ resource "anxcloud_network_prefix" "example" {
 - `ip_version` (Number) The Prefix version: 4 = IPv4, 6 = IPv6.
 - `organization` (String) Customer of yours. Reseller only.
 - `router_redundancy` (Boolean) If router Redundancy shall be enabled.
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `type` (Number) The Prefix type: 0 = Public, 1 = Private.
 - `vlan_id` (String) The corresponding VLAN identifier

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -119,7 +119,7 @@ resource "anxcloud_virtual_server" "example" {
 - `script` (String) Script to be executed after provisioning. Consider the corresponding shebang at the beginning of your script. If you want to use PowerShell, the first line should be: #ps1_sysnative.
 - `sockets` (Number) Amount of CPU sockets Number of cores have to be a multiple of sockets, as they will be spread evenly across all sockets. Defaults to number of cores, i.e. one socket per CPU core.
 - `ssh_key` (String) Public key (instead of password, only for Linux systems). Recommended over providing a plaintext password.
-- `tags` (List of String) List of tags attached to the resource.
+- `tags` (Set of String) Set of tags attached to the resource.
 - `template` (String) Named template. Can be used instead of the template_id to select a template. Example: (`Debian 11`, `Windows 2022`).
 - `template_build` (String) Template build identifier optionally used with `template`. Will default to latest build. Example: `b42`
 - `template_id` (String) Template identifier.


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This PR fixes the tagging middleware to no longer trigger noop update calls of the resource itself if only its tags have changed. The type of the `tags` field has changed from `TypeList` to `TypeSet` and the now obsolete diff-suppression which made the list type act like a set has been removed.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
