### PR TITLE
Disable integration tests for PRs in draft state

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,7 +7,11 @@ on:
   pull_request:
     branches:
     - main
-
+    types: 
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
 env:
   GO_VERSION: 1.18
 
@@ -63,6 +67,7 @@ jobs:
       run: make test
 
   integration-tests:
+    if: '! github.event.pull_request.draft'
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Disable integration tests for PRs in draft state to prevent unnecessary engine load.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
