### PR TITLE
Skip integration tests for dependabot actor

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,7 @@ on:
     - synchronize
     - reopened
     - ready_for_review
+  workflow_dispatch: {}
 env:
   GO_VERSION: 1.19
 
@@ -67,7 +68,7 @@ jobs:
       run: make test
 
   integration-tests:
-    if: '! github.event.pull_request.draft'
+    if: ${{ ! github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:


### PR DESCRIPTION
### Description

Skip automatic integration tests for dependabot PRs. Relevant PRs should be integration tested by manually triggering the `workflow_dispatch`.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
