### PR TITLE
Fix virtual server socket calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Fixed
+* resource/anxcloud_virtual_server now correctly calculates sockets on read (#136, @anx-mschaefer)
+
 ## [0.5.2] - 2023-02-20
 
 ### Added

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -309,11 +309,11 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 	if err = d.Set("cpus", info.CPU); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	if v := d.Get("sockets").(int); v != 0 {
-		// TODO: API fix: info.Cores should be info.Sockets, there is info.Cpus which is info.Cores
-		if err = d.Set("sockets", info.Cores); err != nil {
-			diags = append(diags, diag.FromErr(err)...)
-		}
+
+	// engine ensures that the number of CPUs is divisible by the number of sockets
+	// -> floor division is fine
+	if err = d.Set("sockets", info.CPU/info.Cores); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
 	}
 
 	if err = d.Set("memory", info.RAM); err != nil {

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -67,6 +67,7 @@ func TestAccAnxCloudVirtualServer(t *testing.T) {
 		TemplateType:       "templates",
 		Memory:             2048,
 		CPUs:               2,
+		Sockets:            2,
 		CPUPerformanceType: "performance",
 		Disk:               50,
 		DiskType:           "ENT6",
@@ -161,6 +162,7 @@ func TestAccAnxCloudVirtualServerFromScratch(t *testing.T) {
 		TemplateType:       "from_scratch",
 		Memory:             2048,
 		CPUs:               2,
+		Sockets:            2,
 		CPUPerformanceType: "performance",
 		Disk:               50,
 		DiskType:           "ENT6",
@@ -199,6 +201,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 		Hostname:           fmt.Sprintf("terraform-test-%s-multi-disk-scaling", envInfo.TestRunName),
 		Memory:             2048,
 		CPUs:               2,
+		Sockets:            2,
 		CPUPerformanceType: "performance",
 		Network:            []vm.Network{createNewNetworkInterface(envInfo)},
 		DNS1:               "8.8.8.8",
@@ -372,6 +375,7 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, templateName string
 		
 		hostname             = "%s"
 		cpus                 = %d
+		sockets              = %d
 		cpu_performance_type = "%s"
 		memory               = %d
 		password             = "%s"
@@ -388,7 +392,7 @@ func testAccConfigAnxCloudVirtualServer(resourceName string, templateName string
 		force_restart_if_needed = true
 		critical_operation_confirmed = true
 	}
-	`, resourceName, def.Location, templateConfig, def.Hostname, def.CPUs, def.CPUPerformanceType, def.Memory,
+	`, resourceName, def.Location, templateConfig, def.Hostname, def.CPUs, def.Sockets, def.CPUPerformanceType, def.Memory,
 		def.Password, generateNetworkSubResourceString(def.Network), generateDisksSubResourceString([]vm.Disk{
 			{
 				SizeGBs: def.Disk,

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -60,6 +60,7 @@ func schemaVirtualServer() map[string]*schema.Schema {
 		"sockets": {
 			Type:     schema.TypeInt,
 			Optional: true,
+			Computed: true,
 			Description: "Amount of CPU sockets Number of cores have to be a multiple of sockets, as they will be spread evenly across all sockets. " +
 				"Defaults to number of cores, i.e. one socket per CPU core.",
 		},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Fixed `anxcloud_virtual_server` resource to derive `sockets` attribute from `cpus` and `cores` on read.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
