### PR TITLE
Improve CDNS record resource performance

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -78,7 +78,7 @@ jobs:
         go-version: ${{env.GO_VERSION}}
 
     - name: run integration tests and post coverage to codeclimate
-      uses: paambaati/codeclimate-action@v4.0.0
+      uses: paambaati/codeclimate-action@v5.0.0
       env:
         ANEXIA_LOCATION_ID: 52b5f6b2fd3a4a7eaaedf1a7c019e9ea
         ANEXIA_VLAN_ID: 00a239d617504e4ab49122efe0d27657

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * (internal)? scope: short description (#pr, @author)
 -->
 
+### Changed
+* resource/anxcloud_dns_record:
+  - create and delete operations are now handled in batches internally
+  - attribute changes now trigger a replacement of the resource
+
 ## [0.5.3] - 2023-10-30
 
 ### Fixed

--- a/anxcloud/internal/utils/batcher.go
+++ b/anxcloud/internal/utils/batcher.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type BatchUnitResult[T any] struct {
+	Data  T
+	Error error
+}
+
+type batchUnitRequest[T, U any] struct {
+	in T
+	ch chan BatchUnitResult[U]
+}
+
+type Batcher[T, U any] struct {
+	sync.Mutex
+	batch     []batchUnitRequest[T, U]
+	startWait sync.Once
+	Wait      time.Duration
+	BatchFunc func(context.Context, []T) []BatchUnitResult[U]
+}
+
+func (b *Batcher[T, U]) Process(ctx context.Context, in T) (U, error) {
+	b.Lock()
+	ch := make(chan BatchUnitResult[U], 1)
+	b.batch = append(b.batch, batchUnitRequest[T, U]{in, ch})
+	b.startWait.Do(func() { time.AfterFunc(b.Wait, func() { b.processBatch(ctx) }) })
+	b.Unlock()
+
+	res := <-ch
+	return res.Data, res.Error
+}
+
+func (b *Batcher[T, U]) processBatch(ctx context.Context) {
+	b.Lock()
+	defer b.Unlock()
+
+	in := make([]T, len(b.batch))
+	for i, elem := range b.batch {
+		in[i] = elem.in
+	}
+
+	out := b.BatchFunc(ctx, in)
+	for i, elem := range b.batch {
+		elem.ch <- out[i]
+	}
+
+	b.batch = nil
+	b.startWait = sync.Once{}
+}

--- a/anxcloud/provider.go
+++ b/anxcloud/provider.go
@@ -114,9 +114,6 @@ func handleNotFoundError(err error) error {
 	return err
 }
 
-// context key type for provider package
-type providerContextKey string
-
 func apiFromProviderConfig(m interface{}) api.API {
 	return m.(providerContext).api
 }

--- a/anxcloud/schema_dns_record.go
+++ b/anxcloud/schema_dns_record.go
@@ -13,31 +13,37 @@ func schemaDNSRecord() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "DNS record type.",
+			ForceNew:    true,
 		},
 		"rdata": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "DNS record data.",
+			ForceNew:    true,
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "DNS record name.",
+			ForceNew:    true,
 		},
 		"zone_name": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Zone of DNS record.",
-		},
-		"region": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "DNS record region (for GeoDNS aware records).",
+			ForceNew:    true,
 		},
 		"ttl": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Description: "Region specific TTL. If not set the zone TTL will be used.",
+			ForceNew:    true,
+		},
+
+		"region": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "DNS record region (for GeoDNS aware records).",
 		},
 		"immutable": {
 			Type:        schema.TypeBool,

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -3,12 +3,12 @@
 page_title: "anxcloud_dns_record Resource - terraform-provider-anxcloud"
 subcategory: ""
 description: |-
-  This resource allows you to create DNS records for a specified zone. TXT records might behave funny, we are working on it.
+  This resource allows you to create DNS records for a specified zone. TXT records might behave funny, we are working on it. Create and delete operations will be handled in batches internally. As a side effect this will cause whole batches to fail in case some of the operations are invalid. Updating record attributes triggers a replacement (destroy old -> create new).
 ---
 
 # anxcloud_dns_record (Resource)
 
-This resource allows you to create DNS records for a specified zone. TXT records might behave funny, we are working on it.
+This resource allows you to create DNS records for a specified zone. TXT records might behave funny, we are working on it. Create and delete operations will be handled in batches internally. As a side effect this will cause whole batches to fail in case some of the operations are invalid. Updating record attributes triggers a replacement (destroy old -> create new).
 
 ## Example Usage
 
@@ -52,6 +52,5 @@ Optional:
 - `create` (String)
 - `delete` (String)
 - `read` (String)
-- `update` (String)
 
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This PR introduces batch creation and deletion for dns records (`anxcloud_dns_record`) which are in the same zone. This greatly improves performance when managing multiple records.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
