### PR TITLE
Rename vet to govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,4 +18,4 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet


### PR DESCRIPTION
> WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet.

This removes said warning.