### PR TITLE
Handle missing VM info more gracefully to prevent division by zero panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 
 * (internal)? scope: short description (#pr, @author)
 -->
+
+### Fixed
+* resource/anxcloud_virtual_server: Handle missing VM info more gracefully to prevent division by zero panic (#170, @anx-mschaefer)
+
 ## [0.6.4] - 2024-06-27
 
 The v0.6.3 release wasn't published because there was an issue in our release workflow.

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -293,9 +293,15 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	// engine ensures that the number of CPUs is divisible by the number of sockets
-	// -> floor division is fine
-	if err = d.Set("sockets", info.CPU/info.Cores); err != nil {
+	var sockets int
+	if info.Cores > 0 {
+		// engine ensures that the number of CPUs is divisible by the number of sockets
+		// -> floor division is fine
+		sockets = info.CPU / info.Cores
+	} else {
+		diags = append(diags, diag.Errorf("The engine didn't report any cores for this VM. This is likely a temporary issue. Please try again.")...)
+	}
+	if err = d.Set("sockets", sockets); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
VM info endpoint doesn't always report the number of cores of a VM. That caused a division by zero panic.
This PR handles missing info about a VMs cores more gracefully.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
