### PR TITLE
Implement setting bandwidth_limit on a servers network interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 
 * (internal)? scope: short description (#pr, @author)
 -->
+## Added
+* Add ability to set the bandwidth limit per network interface on the server resource (#206 @89q12)
 
 ### Fixed
 * resource/anxcloud_virtual_server: Handle missing VM info more gracefully to prevent division by zero panic (#170, @anx-mschaefer)

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -522,10 +522,10 @@ func testAccCheckAnxCloudVirtualServerDisks(n string, expectedDisks []vm.Disk) r
 
 func generateNetworkSubResourceString(networks []vm.Network) string {
 	var output string
-	template := "\nnetwork {\n\tvlan_id = \"%s\"\n\tnic_type = \"%s\"\n\tips = [\"%s\"]\n}\n"
+	template := "\nnetwork {\n\tvlan_id = \"%s\"\n\tnic_type = \"%s\"\n\tbandwidth_limit = \"%s\"\n\tips = [\"%s\"]\n}\n"
 
 	for _, n := range networks {
-		output += fmt.Sprintf(template, n.VLAN, n.NICType, n.IPs[0])
+		output += fmt.Sprintf(template, n.VLAN, n.NICType, fmt.Sprint(n.BandwidthLimit), n.IPs[0])
 	}
 
 	return output
@@ -598,9 +598,10 @@ func TestVersionParsing(t *testing.T) {
 
 func createNewNetworkInterface(info environment.Info) vm.Network {
 	return vm.Network{
-		VLAN:    info.VlanID,
-		NICType: "virtio",
-		IPs:     []string{info.Prefix.GetNextIP()},
+		VLAN:           info.VlanID,
+		NICType:        "virtio",
+		IPs:            []string{info.Prefix.GetNextIP()},
+		BandwidthLimit: 1000,
 	}
 }
 

--- a/anxcloud/schema_virtual_server.go
+++ b/anxcloud/schema_virtual_server.go
@@ -114,6 +114,12 @@ func schemaVirtualServer() map[string]*schema.Schema {
 						Required:    true,
 						Description: "Network interface card type.",
 					},
+					"bandwidth_limit": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Default:     1000,
+						Description: "Network interface bandwidth limit in Megabit/s, default: 1000",
+					},
 					"ips": {
 						Type:     schema.TypeSet,
 						Optional: true,
@@ -327,6 +333,11 @@ func schemaVirtualServer() map[string]*schema.Schema {
 									Type:        schema.TypeInt,
 									Computed:    true,
 									Description: "NIC type number.",
+								},
+								"bandwidth_limit": {
+									Type:        schema.TypeInt,
+									Computed:    true,
+									Description: "Bandwidth limit of the interface in Megabit/s",
 								},
 								"vlan": {
 									Type:        schema.TypeString,

--- a/anxcloud/struct_virtual_server.go
+++ b/anxcloud/struct_virtual_server.go
@@ -24,6 +24,9 @@ func expandVirtualServerNetworks(p []interface{}) []vm.Network {
 		if v, ok := in["nic_type"]; ok {
 			network.NICType = v.(string)
 		}
+		if v, ok := in["bandwidth_limit"]; ok {
+			network.BandwidthLimit = v.(int)
+		}
 		if v, ok := in["ips"]; ok {
 			ips := v.(*schema.Set)
 			for _, ip := range ips.List() {
@@ -230,6 +233,7 @@ func flattenVirtualServerNetwork(in []vm.Network) []interface{} {
 		net["vlan_id"] = n.VLAN
 		net["nic_type"] = n.NICType
 		net["ips"] = n.IPs
+		net["bandwidth_limit"] = n.BandwidthLimit
 		att = append(att, net)
 	}
 
@@ -281,6 +285,7 @@ func flattenVirtualServerInfo(in *info.Info) []interface{} {
 		ni["mac_address"] = n.MACAddress
 		ni["ip_v4"] = n.IPv4
 		ni["ip_v6"] = n.IPv6
+		ni["bandwidth_limit"] = n.BandwidthLimit
 		networkInfo = append(networkInfo, ni)
 	}
 	att["network"] = networkInfo

--- a/anxcloud/struct_virtual_server_test.go
+++ b/anxcloud/struct_virtual_server_test.go
@@ -19,8 +19,9 @@ func TestExpanderVirtualServerNetworks(t *testing.T) {
 		{
 			[]interface{}{
 				map[string]interface{}{
-					"vlan_id":  "38f8561acfe34qc49c336d2af31a5cc3",
-					"nic_type": "virtio",
+					"vlan_id":         "38f8561acfe34qc49c336d2af31a5cc3",
+					"nic_type":        "virtio",
+					"bandwidth_limit": 1000,
 					"ips": schema.NewSet(schema.HashSchema(&schema.Schema{Type: schema.TypeString}), []interface{}{
 						"identifier1",
 						"identifier2",
@@ -31,8 +32,9 @@ func TestExpanderVirtualServerNetworks(t *testing.T) {
 			},
 			[]vm.Network{
 				{
-					VLAN:    "38f8561acfe34qc49c336d2af31a5cc3",
-					NICType: "virtio",
+					VLAN:           "38f8561acfe34qc49c336d2af31a5cc3",
+					NICType:        "virtio",
+					BandwidthLimit: 1000,
 					IPs: []string{
 						"10.11.12.13",
 						"1.0.0.1",
@@ -283,8 +285,9 @@ func TestFlattenVirtualServerNetwork(t *testing.T) {
 		{
 			[]vm.Network{
 				{
-					VLAN:    "38f8561acfe34qc49c336d2af31a5cc3",
-					NICType: "virtio",
+					VLAN:           "38f8561acfe34qc49c336d2af31a5cc3",
+					NICType:        "virtio",
+					BandwidthLimit: 1000,
 					IPs: []string{
 						"identifier1",
 						"identifier2",
@@ -295,8 +298,9 @@ func TestFlattenVirtualServerNetwork(t *testing.T) {
 			},
 			[]interface{}{
 				map[string]interface{}{
-					"vlan_id":  "38f8561acfe34qc49c336d2af31a5cc3",
-					"nic_type": "virtio",
+					"vlan_id":         "38f8561acfe34qc49c336d2af31a5cc3",
+					"nic_type":        "virtio",
+					"bandwidth_limit": 1000,
 					"ips": []string{
 						"identifier1",
 						"identifier2",
@@ -336,12 +340,13 @@ func TestFlattenVirtualServerInfo(t *testing.T) {
 				Cores:           4,
 				Network: []info.Network{
 					{
-						NIC:        3,
-						ID:         4000,
-						VLAN:       "111111111111111111111",
-						MACAddress: "00:50:56:bb:c0:81",
-						IPv4:       []string{"1.1.1.1"},
-						IPv6:       []string{"2001:db8::8a2e:370:7334"},
+						NIC:            3,
+						BandwidthLimit: 1000,
+						ID:             4000,
+						VLAN:           "111111111111111111111",
+						MACAddress:     "00:50:56:bb:c0:81",
+						IPv4:           []string{"1.1.1.1"},
+						IPv6:           []string{"2001:db8::8a2e:370:7334"},
 					},
 				},
 				Disks: 1,
@@ -372,12 +377,13 @@ func TestFlattenVirtualServerInfo(t *testing.T) {
 					"status":           "poweredOn",
 					"network": []interface{}{
 						map[string]interface{}{
-							"nic":         3,
-							"id":          4000,
-							"vlan":        "111111111111111111111",
-							"mac_address": "00:50:56:bb:c0:81",
-							"ip_v4":       []string{"1.1.1.1"},
-							"ip_v6":       []string{"2001:db8::8a2e:370:7334"},
+							"nic":             3,
+							"bandwidth_limit": 1000,
+							"id":              4000,
+							"vlan":            "111111111111111111111",
+							"mac_address":     "00:50:56:bb:c0:81",
+							"ip_v4":           []string{"1.1.1.1"},
+							"ip_v6":           []string{"2001:db8::8a2e:370:7334"},
 						},
 					},
 					"ram":          4096,

--- a/docs/resources/virtual_server.md
+++ b/docs/resources/virtual_server.md
@@ -13,6 +13,7 @@ The virtual_server resource allows you to configure and run virtual machines.
 ### Known limitations
 - removal of disks not supported
 - removal of networks not supported
+- changing the speed on a network interface forces a replacement of the VM
 
 ## Example Usage
 
@@ -74,9 +75,10 @@ resource "anxcloud_virtual_server" "example" {
 
   # Set network interface
   network {
-    vlan_id  = anxcloud_vlan.example.id
-    ips      = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
-    nic_type = "virtio"
+    vlan_id         = anxcloud_vlan.example.id
+    ips             = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
+    nic_type        = "virtio"
+    bandwidth_limit = 1000
   }
 
   # Disk 1
@@ -158,8 +160,8 @@ Required:
 
 Optional:
 
-- `ips` (List of String) Requested list of IPs and IPs identifiers. IPs are ignored when using template_type 'from_scratch'. Defaults to free IPs from IP pool attached to VLAN.
-
+- `bandwidth_limit` (Number) Network interface bandwidth limit in Megabit/s, default: 1000
+- `ips` (Set of String) Requested set of IPs and IPs identifiers. IPs are ignored when using template_type 'from_scratch'. Defaults to free IPs from IP pool attached to VLAN.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
@@ -220,5 +222,6 @@ Read-Only:
 - `mac_address` (String) MAC address of the NIC.
 - `nic` (Number) NIC type number.
 - `vlan` (String) VLAN identifier.
+- `bandwidth_limit` (Number) Network interface bandwidth limit in Megabit/s, default: 1000
 
 

--- a/examples/resources/anxcloud_virtual_server/resource.tf
+++ b/examples/resources/anxcloud_virtual_server/resource.tf
@@ -58,6 +58,7 @@ resource "anxcloud_virtual_server" "example" {
     vlan_id  = anxcloud_vlan.example.id
     ips      = [anxcloud_ip_address.v4.id, anxcloud_ip_address.v6.id]
     nic_type = "virtio"
+    bandwidth_limit = 1000
   }
 
   # Disk 1

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 
 require (
 	github.com/go-logr/stdr v1.2.2 // indirect
-	golang.org/x/net v0.28.0 // indirect
+	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.9.0
-	go.anx.io/go-anxcloud v0.7.4
+	go.anx.io/go-anxcloud v0.7.6
 	k8s.io/client-go v0.31.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,13 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.9.0
-	go.anx.io/go-anxcloud v0.7.5
+	go.anx.io/go-anxcloud v0.7.4
 	k8s.io/client-go v0.31.1
 )
 
 require (
 	github.com/go-logr/stdr v1.2.2 // indirect
-	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
-go.anx.io/go-anxcloud v0.7.4 h1:+/J66wm299WnwvBd0pMC4qc8Nxvvij0cxUyzpSq1jqo=
-go.anx.io/go-anxcloud v0.7.4/go.mod h1:4OObxqH+9mkf4i4C6VG7u6HCG4qTiMNsj+2kNP60WcE=
+go.anx.io/go-anxcloud v0.7.6 h1:n1dbOtKx85Qpcw6wWrLeLST01zsmwmPyRR3IoyC9QGg=
+go.anx.io/go-anxcloud v0.7.6/go.mod h1:4OObxqH+9mkf4i4C6VG7u6HCG4qTiMNsj+2kNP60WcE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
-go.anx.io/go-anxcloud v0.7.5 h1:FpvaXEXWWp9JS8+wyBggN83h1k9m8KFx9EdYpAdzrNI=
-go.anx.io/go-anxcloud v0.7.5/go.mod h1:4OObxqH+9mkf4i4C6VG7u6HCG4qTiMNsj+2kNP60WcE=
+go.anx.io/go-anxcloud v0.7.4 h1:+/J66wm299WnwvBd0pMC4qc8Nxvvij0cxUyzpSq1jqo=
+go.anx.io/go-anxcloud v0.7.4/go.mod h1:4OObxqH+9mkf4i4C6VG7u6HCG4qTiMNsj+2kNP60WcE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
After the go-anxcloud release, we now implement the `bandwidth_limit` field on the server network interface.
This currently is rebased onto the dependabot branch to be able access the newly added field in go-anxcloud.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
