### PR TITLE
SYSENG-1814 ignore empty template_id from Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 * Add ability to set the bandwidth limit per network interface on the server resource (#206 @89q12)
 
 ### Fixed
+* resource/anxcloud_virtual_server: Handle empty template_id from API and make integration-test pass (#208, @drpsychick)
 * resource/anxcloud_virtual_server: Handle missing VM info more gracefully to prevent division by zero panic (#170, @anx-mschaefer)
 
 ## [0.6.4] - 2024-06-27

--- a/anxcloud/resource_virtual_server.go
+++ b/anxcloud/resource_virtual_server.go
@@ -278,9 +278,13 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 		return nil
 	}
 
-	// `template_id` field isn't set for VMs with "from_scratch" templates
-	// that's why we keep the configured `template_id` if the `template_type` is "from_scratch"
-	if templateType, ok := d.Get("template_type").(string); !ok || templateType != "from_scratch" {
+	// Template Type and ID:
+	// the API never returns the TemplateType and in some cases returns a TemplateID.
+	// TemplateType = "from_scratch" : we expect the TemplateID to be empty
+	// TemplateType = "templates" (default): we expect the TemplateID to be set and match resourceData
+
+	// only update the resource if the API returns a TemplateID
+	if info.TemplateID != "" {
 		if err = d.Set("template_id", info.TemplateID); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
@@ -292,9 +296,6 @@ func resourceVirtualServerRead(ctx context.Context, d *schema.ResourceData, m in
 	if err = d.Set("location_id", info.LocationID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	//if err = d.Set("template_type", info.TemplateType); err != nil {
-	//	diags = append(diags, diag.FromErr(err)...)
-	//}
 	if err = d.Set("cpus", info.CPU); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/anxcloud/resource_virtual_server_test.go
+++ b/anxcloud/resource_virtual_server_test.go
@@ -41,7 +41,7 @@ func getVMRecorder(t *testing.T) recorder.VMRecoder {
 	return vmRecorder
 }
 
-func TestAccAnxCloudVirtualServer(t *testing.T) {
+func TestAccAnxCloudVirtualServerScale(t *testing.T) {
 	environment.SkipIfNoEnvironment(t)
 	resourceName := "acc_test_vm_test"
 	resourcePath := "anxcloud_virtual_server." + resourceName
@@ -210,7 +210,6 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 		DNS1:               "8.8.8.8",
 		Password:           "flatcar#1234$%%",
 	}
-	vmRecorder.RecordVMByName(fmt.Sprintf("%%-%s", vmDef.Hostname))
 
 	disks := []vm.Disk{
 		{
@@ -223,6 +222,7 @@ func TestAccAnxCloudVirtualServerMultiDiskScaling(t *testing.T) {
 		addDiskDef := vmDef
 		addDiskDef.Hostname = fmt.Sprintf("terraform-test-%s-add-disk", envInfo.TestRunName)
 		addDiskDef.Network = []vm.Network{createNewNetworkInterface(envInfo)}
+		vmRecorder.RecordVMByName(fmt.Sprintf("%%-%s", vmDef.Hostname))
 
 		disksAdd := append(disks, vm.Disk{
 


### PR DESCRIPTION
### Description
Contrary to documentation, the API does not return the template_id a VM was created with, but an empty one. We ignore the empty template_id so that it does not trigger a VM change. 

The template_id is stored in local TF state and a change of the template_id in terraform will trigger recreating the VM.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References
