### PR TITLE
SYSENG-1839: add support for apiserver_allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ If the change isn't user-facing but still relevant enough for a changelog entry,
 -->
 ## Added
 * Add ability to set the bandwidth limit per network interface on the server resource (#206 @89q12)
+* Add ability to limit kubernetes API server access via CIDRs (#228 @drpsychick))
 
 ### Fixed
 * resource/anxcloud_virtual_server: Handle empty template_id from API and make integration-test pass (#208, @drpsychick)

--- a/anxcloud/resource_kubernetes_cluster.go
+++ b/anxcloud/resource_kubernetes_cluster.go
@@ -54,6 +54,13 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 		EnableAutoscaling: pointer.Bool(d.Get("enable_autoscaling").(bool)),
 	}
 
+	allowlistAsInterfaces := d.Get("apiserver_allowlist").([]interface{})
+	allowlist := make([]string, 0, len(allowlistAsInterfaces))
+	for _, v := range allowlistAsInterfaces {
+		allowlist = append(allowlist, v.(string))
+	}
+	cluster.ApiServerAllowlist = strings.Join(allowlist, " ")
+
 	if prefix, ok := d.GetOk("internal_ipv4_prefix"); ok {
 		cluster.InternalIPv4Prefix = &common.PartialResource{Identifier: prefix.(string)}
 		cluster.ManageInternalIPv4Prefix = pointer.Bool(false)

--- a/anxcloud/schema_kubernetes.go
+++ b/anxcloud/schema_kubernetes.go
@@ -83,7 +83,7 @@ Enable autoscaling for this cluster. Defaults to false if unset.
 		},
 		"apiserver_allowlist": {
 			Type:        schema.TypeList,
-			Description: "A list of CIDRs that should be allowed access to the kubernetes API server, by default there is no IP restriction.",
+			Description: "A list of CIDRs that should be allowed access to the kubernetes API server. By default there are no IP restrictions.",
 			Optional:    true,
 			Computed:    true,
 			ForceNew:    false,

--- a/anxcloud/schema_kubernetes.go
+++ b/anxcloud/schema_kubernetes.go
@@ -81,6 +81,16 @@ Enable autoscaling for this cluster. Defaults to false if unset.
 			Optional: true,
 			ForceNew: true,
 		},
+		"apiserver_allowlist": {
+			Type:        schema.TypeList,
+			Description: "A list of CIDRs that should be allowed access to the kubernetes API server, by default there is no IP restriction.",
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    false,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 	}
 }
 

--- a/anxcloud/schema_kubernetes.go
+++ b/anxcloud/schema_kubernetes.go
@@ -86,7 +86,7 @@ Enable autoscaling for this cluster. Defaults to false if unset.
 			Description: "A list of CIDRs that should be allowed access to the kubernetes API server. By default there are no IP restrictions.",
 			Optional:    true,
 			Computed:    true,
-			ForceNew:    false,
+			ForceNew:    true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},

--- a/anxcloud/struct_kubernetes.go
+++ b/anxcloud/struct_kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	kubernetesv1 "go.anx.io/go-anxcloud/pkg/apis/kubernetes/v1"
 	"go.anx.io/go-anxcloud/pkg/utils/pointer"
+	"strings"
 )
 
 const gibiFactor = 1073741824 // math.Pow(2, 30)
@@ -47,6 +48,9 @@ func setResourceDataFromKubernetesCluster(d *schema.ResourceData, cluster kubern
 		if err := d.Set("external_ipv6_prefix", cluster.ExternalIPv6Prefix.Identifier); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
+	}
+	if err := d.Set("apiserver_allowlist", strings.Split(cluster.ApiServerAllowlist, " ")); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
 	}
 
 	return diags


### PR DESCRIPTION
### Description

Adding support for `apiserver_allowlist` to restrict access to the kubernetes API server. Update of this field is not yet supported, so it must be provided during cluster creation.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
