### PR TITLE
resource/ip_address: retry delete on transient 'still assigned to a r…

### DIFF
--- a/anxcloud/resource_ip_address.go
+++ b/anxcloud/resource_ip_address.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -22,6 +23,25 @@ const (
 	ipAddressStatusActive   = "Active"
 	ipAddressStatusDeleted  = "Marked for deletion"
 )
+
+// stillAssignedErrorMessage is the substring the API returns in
+// ResponseError.ErrorData.Message when an IP address delete is attempted
+// before the backend has finished detaching it from a resource (e.g. a
+// virtual server's NIC) that was just deleted. This is an eventual
+// consistency gap on the API side rather than a real conflict, so callers
+// should retry on it instead of failing immediately.
+const stillAssignedErrorMessage = "is still assigned to a resource"
+
+// isStillAssignedError returns true if err is a ResponseError caused by the
+// IP address still being assigned to a resource that is in the process of
+// being detached/deleted.
+func isStillAssignedError(err error) bool {
+	var respErr *client.ResponseError
+	if errors.As(err, &respErr) {
+		return strings.Contains(respErr.ErrorData.Message, stillAssignedErrorMessage)
+	}
+	return false
+}
 
 func resourceIPAddress() *schema.Resource {
 	return &schema.Resource{
@@ -357,12 +377,29 @@ func resourceIPAddressDelete(ctx context.Context, d *schema.ResourceData, m inte
 		return diags
 	}
 
-	err := a.Delete(ctx, d.Id())
-	if err != nil {
-		if err := handleNotFoundError(err); err != nil {
-			return diag.FromErr(err)
+	// The backend can return a conflict here if the IP address hasn't
+	// finished being detached from a resource that was just deleted (e.g. a
+	// virtual server's NIC), even though tofu/terraform ordered the deletes
+	// correctly. This is an eventual-consistency gap on the API side, so we
+	// retry the delete call itself instead of failing immediately.
+	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
+		err := a.Delete(ctx, d.Id())
+		if err == nil {
+			return nil
+		}
+		if isStillAssignedError(err) {
+			return retry.RetryableError(fmt.Errorf("ip address '%s' is still assigned to a resource, retrying: %w", d.Id(), err))
+		}
+		if nfErr := handleNotFoundError(err); nfErr != nil {
+			return retry.NonRetryableError(nfErr)
 		}
 		d.SetId("")
+		return nil
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if d.Id() == "" {
 		return nil
 	}
 


### PR DESCRIPTION
resource/ip_address: retry delete on transient "still assigned to a resource" conflict

### Description
This PR was created with the help of AI. 
`anxcloud_ip_address` deletion can intermittently fail with:

```
is still assigned to a resource. Validation:map[]
```

This happens when the IP address is destroyed together with an
`anxcloud_virtual_server` that used it (e.g. on a full `terraform destroy` /
`tofu destroy`). Even though the dependency graph is correct — the VM is
destroyed before the IP address — the VM delete call appears to return
before the backend has fully released/detached the IP from the NIC. The
subsequent delete call for `anxcloud_ip_address` is then rejected because
the API still considers the IP assigned.

Splitting the destroy into two runs (VM first, then a second full destroy)
reliably avoids the failure, which points to a timing/eventual-consistency
gap on the API side rather than incorrect dependency resolution in the
provider or in Terraform/OpenTofu itself.

Root cause in this repo: `resourceIPAddressDelete` only retries *after* a
successful `Delete` call, polling until the address reaches status
`"Marked for deletion"`. The initial `Delete` call itself was never
retried — any error other than 404 aborted the delete immediately via
`diag.FromErr(err)`, before the existing retry loop was ever reached.

This PR wraps the initial `Delete` call in a `retry.RetryContext` and
specifically retries when the error message matches `"is still assigned to
a resource"`, giving the backend time to finish detaching the IP before
giving up. All other errors (e.g. genuine 404s) are still handled and
surfaced exactly as before.

Note: the delete-retry phase and the existing post-delete status-poll
phase each use the full `Delete` timeout (default 5 minutes), so
worst-case total delete time is now roughly double what it was. Happy to
split the timeout budget between the two phases, or bump the default
`Delete` timeout, if that's preferred.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment